### PR TITLE
feat: 🔥 update rgb() to return dynamically generated rgb string

### DIFF
--- a/packages/falso/src/lib/rgb.ts
+++ b/packages/falso/src/lib/rgb.ts
@@ -1,20 +1,7 @@
-import { rand } from './core';
+function randomValue() {
+  return Math.floor(Math.random() * (255 + 1));
+}
 
 export function rgb() {
-  return rand([
-    'rgb(193, 66, 66)',
-    'rgb(63, 191, 63)',
-    'rgb(191, 63, 127)',
-    'rgb(0,0,128)',
-    'rgb(0,255,0)',
-    'rgb(0,255,255)',
-    'rgb(128,0,0)',
-    'rgb(128,0,128)',
-    'rgb(128,128,0)',
-    'rgb(128,128,128)',
-    'rgb(192,192,192)',
-    'rgb(255,0,255)',
-    'rgb(255,255,0)',
-    'rgb(255,255,255)'
-  ]);
+  return `rgb(${randomValue()}, ${randomValue()}, ${randomValue()})`;
 }

--- a/packages/falso/src/sketch.spec.ts
+++ b/packages/falso/src/sketch.spec.ts
@@ -1,5 +1,30 @@
-import { fullName } from './index';
+import { rgb } from "./lib/rgb";
 
-test('', () => {
-  console.log(fullName());
+describe('rgb', () => {
+  it('should return a rgb string in the correct format', () => {
+    const expected = /rgb\((\d{1,3}), (\d{1,3}), (\d{1,3})\)/;
+
+    expect(rgb()).toEqual(expect.stringMatching(expected));
+  });
+
+  it('should return red value between 0 and 255', () => {
+    const colourValues = rgb().match(/\d+/g)?.map(Number);
+
+    expect(colourValues?.[0]).toBeGreaterThanOrEqual(0);
+    expect(colourValues?.[0]).toBeLessThanOrEqual(255);
+  });
+
+  it('should return green value between 0 and 255', () => {
+    const colourValues = rgb().match(/\d+/g)?.map(Number);
+
+    expect(colourValues?.[1]).toBeGreaterThanOrEqual(0);
+    expect(colourValues?.[1]).toBeLessThanOrEqual(255);
+  });
+
+  it('should return blue value between 0 and 255', () => {
+    const colourValues = rgb().match(/\d+/g)?.map(Number);
+
+    expect(colourValues?.[2]).toBeGreaterThanOrEqual(0);
+    expect(colourValues?.[2]).toBeLessThanOrEqual(255);
+  });
 });

--- a/packages/falso/src/tests/rgb.spec.ts
+++ b/packages/falso/src/tests/rgb.spec.ts
@@ -1,4 +1,4 @@
-import { rgb } from "./lib/rgb";
+import { rgb } from "../lib/rgb";
 
 describe('rgb', () => {
   it('should return a rgb string in the correct format', () => {


### PR DESCRIPTION
Update rgb function to dynamically generate rgb strings rather than
picking one from predetermined list. Add basic unit tests for rgb
function.

✅ Closes: #4 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behaviour?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `rgb` function returns an RGB string from a static list.

Issue Number: 4

## What is the new behaviour?
The `rgb` function generates and returns a dynamic RGB string

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
