### PR TITLE
refactor: 💡 Updated Falso generator to support JSON repo / FakeOption

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,11 @@
 🙏 We would ❤️ for you to contribute to Falso and help make it even better than it is today!
 
 ## Developing
+
 - Run `npm i`
-- Create new falso by running `yarn f name`
+- Create new falso by running `yarn new --name name --json`
+
+  - Use `--json` (default `false`) to indicate that the falso will load it's data from a JSON file
 
 ## <a name="rules"></a> Coding Rules
 
@@ -17,7 +20,7 @@ To ensure consistency throughout the source code, keep these rules in mind as yo
 
 We have very precise rules over how our git commit messages can be formatted. This leads to **more
 readable messages** that are easy to follow when looking through the **project history**. But also,
-we use the git commit messages to **generate the Akita changelog**.
+we use the git commit messages to **generate the Falso changelog**.
 
 ### Commit Message Format
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,10 @@
 ## Developing
 
 - Run `npm i`
-- Create new falso by running `yarn new --name name --json`
+- Create new falso by running `yarn new --name name`
 
   - Use `--json` (default `false`) to indicate that the falso will load it's data from a JSON file
+  - Use `--skip-test` (default `false`) to indicate that the falso should not generate a test file
 
 ## <a name="rules"></a> Coding Rules
 

--- a/tools/generators/falso/index.ts
+++ b/tools/generators/falso/index.ts
@@ -2,21 +2,40 @@ import { Tree, getProjects, formatFiles, names } from '@nrwl/devkit';
 import { join } from 'path';
 import { appendFile } from 'fs/promises';
 
-export default async function (tree: Tree, { name, project }: { name: string, project: string }) {
-
+export default async function (
+  tree: Tree,
+  { name, project, json }: { name: string; project: string; json: boolean }
+) {
   const sourceRoot = getProjects(tree).get(project)?.sourceRoot;
 
   const n = names(name);
 
   if (sourceRoot) {
-    tree.write(join(sourceRoot, 'lib', `${n.fileName}.ts`), ` 
-      import { rand } from './core';
-      
-      export function ${n.propertyName}() {
-        return rand([
-        ])
+    if (json) {
+      tree.write(
+        join(sourceRoot, 'lib', `${n.fileName}.json`),
+        `
+        {
+          "data": [
+          ]
+        }
+      `
+      );
+    }
+
+    tree.write(
+      join(sourceRoot, 'lib', `${n.fileName}.ts`),
+      `
+      import { FakeOptions, fake } from './core';
+      ${json ? `import { data } from './${n.fileName}.json'` : ''}
+
+      export function ${
+        n.propertyName
+      }<Options extends FakeOptions>(options?: Options) {
+        return fake(${json ? 'data' : '[]'}, options);
       }
-    `)
+    `
+    );
 
     const index = join(sourceRoot, `index.ts`);
 

--- a/tools/generators/falso/schema.json
+++ b/tools/generators/falso/schema.json
@@ -20,6 +20,12 @@
       "description": "Include json data file for falso",
       "alias": "j"
     },
+    "skipTest": {
+      "type": "boolean",
+      "default": false,
+      "description": "Skip spec file creation for falso",
+      "alias": "s"
+    },
     "project": {
       "type": "string",
       "default": "falso",

--- a/tools/generators/falso/schema.json
+++ b/tools/generators/falso/schema.json
@@ -3,6 +3,7 @@
   "cli": "nx",
   "$id": "falso",
   "type": "object",
+  "additionalProperties": false,
   "properties": {
     "name": {
       "type": "string",
@@ -10,7 +11,14 @@
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "alias": "n"
+    },
+    "json": {
+      "type": "boolean",
+      "default": false,
+      "description": "Include json data file for falso",
+      "alias": "j"
     },
     "project": {
       "type": "string",
@@ -18,7 +26,5 @@
       "description": "Project name"
     }
   },
-  "required": [
-    "name"
-  ]
+  "required": ["name"]
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The falso workspace generator did not :

- create a matching `.json` file for the newly to add falso
- declare function with `FakeOptions` parameter / type


## What is the new behavior?

The falso workspace generate will :

- generating a matchin falso JSON file according `--json` option value (default : `false`) 
- support `FakeOptions` to function definition

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
