### PR TITLE
fix: 🐞 Ensure that fullstop is appended when wordCount is met

### DIFF
--- a/packages/falso/src/lib/sentence.ts
+++ b/packages/falso/src/lib/sentence.ts
@@ -1,10 +1,12 @@
 import { FakeOptions, fake, getRandomInRange } from './core/core';
 import { randWord } from './word';
 
-function getSpecialCharacter(): string {
+const maxWords = 50;
+
+function getSpecialCharacter(wordCount: number): string {
   const randomNumber = getRandomInRange({ min: 1, max: 10, fraction: 0 });
 
-  if (randomNumber === 1) {
+  if (randomNumber === 1 || wordCount === maxWords) {
     return '.';
   }
 
@@ -32,14 +34,16 @@ function getSpecialCharacter(): string {
 export function randSentence<Options extends FakeOptions>(options?: Options) {
   const factory = () => {
     let text = randWord({ capitalize: true });
-    let totalWords = 1;
+    let wordCount = 1;
 
-    while (totalWords < 50) {
+    while (wordCount < maxWords) {
       const randomWord = randWord();
       let specialChar = '';
 
-      if (totalWords > 2) {
-        specialChar = getSpecialCharacter();
+      wordCount++;
+
+      if (wordCount > 3) {
+        specialChar = getSpecialCharacter(wordCount);
       }
 
       text += ` ${randomWord}${specialChar}`;
@@ -47,8 +51,6 @@ export function randSentence<Options extends FakeOptions>(options?: Options) {
       if (specialChar === '.') {
         break;
       }
-
-      totalWords++;
     }
 
     return text;

--- a/packages/falso/src/tests/sentence.spec.ts
+++ b/packages/falso/src/tests/sentence.spec.ts
@@ -1,4 +1,4 @@
-import { randSentence } from '@ngneat/falso';
+import { randSentence } from '../lib/sentence';
 
 describe('randSentence', () => {
   it('should start with a capital letter', () => {
@@ -56,10 +56,9 @@ describe('randSentence', () => {
 
       it('should return a string array with 3 items, each ending with a full-stop', () => {
         const result = randSentence({ length: 3 });
-        // TODO FIX TEST
-        // expect(result[0]?.slice(-1)).toEqual('.');
-        // expect(result[1]?.slice(-1)).toEqual('.');
-        // expect(result[2]?.slice(-1)).toEqual('.');
+        expect(result[0]?.slice(-1)).toEqual('.');
+        expect(result[1]?.slice(-1)).toEqual('.');
+        expect(result[2]?.slice(-1)).toEqual('.');
       });
     });
   });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If the word count is met, the loop is broken before full-stop is appended
Demonstrated in [this comment](https://github.com/ngneat/falso/pull/23#issuecomment-1013841367)

Issue Number: N/A

## What is the new behavior?
Check for word count when adding special character

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
