### PR TITLE
feat: extend randProtocol to return full names of protocols #86

### DIFF
--- a/packages/falso/src/lib/protocol-full.json
+++ b/packages/falso/src/lib/protocol-full.json
@@ -1,0 +1,15 @@
+{
+  "data": [
+    "Hyper Text Transfer Protocol Secure",
+    "Hyper Text Transfer Protocol",
+    "Transmission Control Protocol",
+    "User Datagram Protocol",
+    "Internet Protocol",
+    "Post office Protocol",
+    "Simple mail transport Protocol",
+    "Dynamic Host Configuration Protoco",
+    "Layer Two Tunnelling Protocol",
+    "File Transfer Protocol",
+    "Internet Message Access Protocol"
+  ]
+}

--- a/packages/falso/src/lib/protocol.json
+++ b/packages/falso/src/lib/protocol.json
@@ -1,3 +1,15 @@
 {
-  "data": ["https", "http"]
+  "data": [
+    "https",
+    "http",
+    "tcp",
+    "udp",
+    "ip",
+    "pop",
+    "smtp",
+    "dhcp",
+    "l2tp",
+    "ftp",
+    "imap"
+  ]
 }

--- a/packages/falso/src/lib/protocol.ts
+++ b/packages/falso/src/lib/protocol.ts
@@ -1,5 +1,10 @@
 import { FakeOptions, fake } from './core/core';
-import { data } from './protocol.json';
+import { data as protocol } from './protocol.json';
+import { data as protocolFull } from './protocol-full.json';
+
+interface ProtocolOptions extends FakeOptions {
+  fullName?: boolean;
+}
 
 /**
  * Generate a random protocol.
@@ -14,7 +19,13 @@ import { data } from './protocol.json';
  *
  * randProtocol({ length: 10 })
  *
+ * @example
+ *
+ * randProtocol({ fullName: true })
+ *
  */
-export function randProtocol<Options extends FakeOptions>(options?: Options) {
-  return fake(data, options);
+export function randProtocol<Options extends ProtocolOptions>(
+  options?: Options
+) {
+  return fake(options?.fullName ? protocolFull : protocol, options);
 }

--- a/packages/falso/src/tests/protocol.spec.ts
+++ b/packages/falso/src/tests/protocol.spec.ts
@@ -1,0 +1,14 @@
+import { randProtocol } from '../lib/protocol';
+
+describe('protocol', () => {
+  it('should create a protocol', () => {
+    const protocol = randProtocol();
+
+    expect(typeof protocol).toEqual('string');
+  });
+  it('should create a protocol with its full name', () => {
+    const protocol = randProtocol({ fullName: true });
+
+    expect(typeof protocol).toEqual('string');
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Extends the randProtocol method to return full names.

Issue Number: #86

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
