### PR TITLE
fix: 🐞 Full name formatting when length is passed

### DIFF
--- a/packages/falso/src/lib/full-name.ts
+++ b/packages/falso/src/lib/full-name.ts
@@ -25,13 +25,12 @@ export interface NameOptions extends FakeOptions {
  *
  */
 export function randFullName<Options extends NameOptions>(options?: Options) {
-  const factory = () => {
-    const nameOptions = {
-      withAccents: options?.withAccents,
-    };
-
-    return `${randFirstName(nameOptions)} ${randLastName(nameOptions)}`;
+  const nameOptions = {
+    withAccents: options?.withAccents,
   };
 
-  return fake(factory, options);
+  return fake(
+    () => `${randFirstName(nameOptions)} ${randLastName(nameOptions)}`,
+    options
+  );
 }

--- a/packages/falso/src/lib/full-name.ts
+++ b/packages/falso/src/lib/full-name.ts
@@ -25,8 +25,13 @@ export interface NameOptions extends FakeOptions {
  *
  */
 export function randFullName<Options extends NameOptions>(options?: Options) {
-  return fake(
-    () => `${randFirstName(options)} ${randLastName(options)}`,
-    options
-  );
+  const factory = () => {
+    const nameOptions = {
+      withAccents: options?.withAccents,
+    };
+
+    return `${randFirstName(nameOptions)} ${randLastName(nameOptions)}`;
+  };
+
+  return fake(factory, options);
 }

--- a/packages/falso/src/tests/full-name.spec.ts
+++ b/packages/falso/src/tests/full-name.spec.ts
@@ -2,10 +2,13 @@ import { randFullName } from '@ngneat/falso';
 
 describe('fullName', () => {
   let specialCharRegex: RegExp;
+  let nameStructureRegex: RegExp | string;
 
   beforeEach(() => {
     specialCharRegex =
       /[ÞōŌāĀēĒØøłŁàèìòùÀÈÌÒÙáéíóúýÁÉÍÓÚÝâêěîôûčÂĚÊšŠÎÔŪÛŽžÐŻżãñõÃÑÕäëïöüÿÄËÏÖÜŸőŐçÇßðÅåÆæœ]/;
+    nameStructureRegex =
+      /^[a-zA-ZÞōŌāĀēĒØøłŁàèìòùÀÈÌÒÙáéíóúýÁÉÍÓÚÝâêěîôûčÂĚÊšŠÎÔŪÛŽžÐŻżãñõÃÑÕäëïöüÿÄËÏÖÜŸőŐçÇßðÅåÆæœ]+(\-[a-zA-ZÞōŌāĀēĒØøłŁàèìòùÀÈÌÒÙáéíóúýÁÉÍÓÚÝâêěîôûčÂĚÊšŠÎÔŪÛŽžÐŻżãñõÃÑÕäëïöüÿÄËÏÖÜŸőŐçÇßðÅåÆæœ]+)?\s[a-zA-ZÞōŌāĀēĒØøłŁàèìòùÀÈÌÒÙáéíóúýÁÉÍÓÚÝâêěîôûčÂĚÊšŠÎÔŪÛŽžÐŻżãñõÃÑÕäëïöüÿÄËÏÖÜŸőŐçÇßðÅåÆæœ]+(\-[a-zA-ZÞōŌāĀēĒØøłŁàèìòùÀÈÌÒÙáéíóúýÁÉÍÓÚÝâêěîôûčÂĚÊšŠÎÔŪÛŽžÐŻżãñõÃÑÕäëïöüÿÄËÏÖÜŸőŐçÇßðÅåÆæœ]+)?$/;
   });
 
   describe('withAccents is passed', () => {
@@ -19,31 +22,31 @@ describe('fullName', () => {
       it('should return a string with a first name, a space and then last name', () => {
         const result = randFullName({ withAccents: false });
 
-        expect(result.match(/^\w+\s\w+$/)).toBeTruthy();
+        expect(result).toMatch(nameStructureRegex);
       });
 
       it('should return a string should contain accents', () => {
         const result = randFullName({ withAccents });
 
-        expect(result.match(specialCharRegex)).toBeTruthy();
+        expect(result).toMatch(specialCharRegex);
       });
     });
 
-    describe('withAccents is false', () => {
+    describe.only('withAccents is false', () => {
       beforeEach(() => {
         withAccents = false;
       });
 
-      it('should return a string with a first name, a space and then last name', () => {
+      it.only('should return a string with a first name, a space and then last name', () => {
         const result = randFullName({ withAccents: false });
 
-        expect(result.match(/^\w+\s\w+$/)).toBeTruthy();
+        expect(result).toMatch(nameStructureRegex);
       });
 
       it('should not return a string should contain accents', () => {
         const result = randFullName({ withAccents });
 
-        expect(result.match(specialCharRegex)).toBeFalsy();
+        expect(result).not.toMatch(specialCharRegex);
       });
     });
   });

--- a/packages/falso/src/tests/full-name.spec.ts
+++ b/packages/falso/src/tests/full-name.spec.ts
@@ -1,0 +1,61 @@
+import { randFullName } from '@ngneat/falso';
+
+describe('fullName', () => {
+  let specialCharRegex: RegExp;
+
+  beforeEach(() => {
+    specialCharRegex =
+      /[ÞōŌāĀēĒØøłŁàèìòùÀÈÌÒÙáéíóúýÁÉÍÓÚÝâêěîôûčÂĚÊšŠÎÔŪÛŽžÐŻżãñõÃÑÕäëïöüÿÄËÏÖÜŸőŐçÇßðÅåÆæœ]/;
+  });
+
+  describe('withAccents is passed', () => {
+    let withAccents: boolean;
+
+    describe('withAccents is true', () => {
+      beforeEach(() => {
+        withAccents = true;
+      });
+
+      it('should return a string with a first name, a space and then last name', () => {
+        const result = randFullName({ withAccents: false });
+
+        expect(result.match(/^\w+\s\w+$/)).toBeTruthy();
+      });
+
+      it('should return a string should contain accents', () => {
+        const result = randFullName({ withAccents });
+
+        expect(result.match(specialCharRegex)).toBeTruthy();
+      });
+    });
+
+    describe('withAccents is false', () => {
+      beforeEach(() => {
+        withAccents = false;
+      });
+
+      it('should return a string with a first name, a space and then last name', () => {
+        const result = randFullName({ withAccents: false });
+
+        expect(result.match(/^\w+\s\w+$/)).toBeTruthy();
+      });
+
+      it('should not return a string should contain accents', () => {
+        const result = randFullName({ withAccents });
+
+        expect(result.match(specialCharRegex)).toBeFalsy();
+      });
+    });
+  });
+
+  describe('length is passed', () => {
+    it('should not contain commas', () => {
+      // Bug fix #100: Length option was passed to randFirstName & randLastName
+      const [result1, result2, result3] = randFullName({ length: 3 });
+
+      expect(result1).not.toContain(',');
+      expect(result2).not.toContain(',');
+      expect(result3).not.toContain(',');
+    });
+  });
+});


### PR DESCRIPTION
Fix issue where length value is passed to randFirstName and randLastName
meaning the formatting is broken

✅ Closes: #100

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
