### PR TITLE
fix: 🐞 sports category olympicWinter in JSON

### DIFF
--- a/packages/falso/src/lib/sports.json
+++ b/packages/falso/src/lib/sports.json
@@ -47,7 +47,7 @@
       "Weightlifting",
       "Wrestling"
     ],
-    "olympicWinter": [
+    "winterOlympic": [
       "Alpine Skiing",
       "Biathlon",
       "Bobsleigh",

--- a/packages/falso/src/tests/sports.spec.ts
+++ b/packages/falso/src/tests/sports.spec.ts
@@ -21,6 +21,13 @@ describe('sports', () => {
       const sport = randSports({ category: 'olympic' });
       expect(data.olympic).toContain(sport);
     });
+
+    describe('category is winterOlympic', () => {
+      it('should return a sport from the category winterOlympic', () => {
+        const sport = randSports({ category: 'winterOlympic' });
+        expect(data.winterOlympic).toContain(sport);
+      });
+    });
   });
   describe('length is passed', () => {
     describe('length is 1', () => {


### PR DESCRIPTION
Renamed the sports category in JSON from olympicWinter to winterOlympic
to match the type definition

✅ Closes: #201

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 201

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No *
```
\* It's not a breaking change for TS users. If someone uses JS (or `any`) and relies on `olympicWinter` it's a breaking change.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I added a test for the fixed category though I'm not sure if that is correct (let me know if not).