### PR TITLE
feat: 🔥 Add more flight number generators for various airlines

### DIFF
--- a/packages/falso/src/lib/airport.ts
+++ b/packages/falso/src/lib/airport.ts
@@ -24,6 +24,6 @@ export interface Airport {
  */
 export function randAirport<Options extends FakeOptions = never>(
   options?: Options
-): Airport | Airport[] {
+) {
   return fake(data, options);
 }

--- a/packages/falso/src/lib/flight-details.ts
+++ b/packages/falso/src/lib/flight-details.ts
@@ -38,6 +38,10 @@ function generateFlightLength(): number {
  *
  * @example
  *
+ * randFlightDetails({ airline: 'RyanAir' })
+ *
+ * @example
+ *
  * randFlightDetails({ length: 10 })
  *
  */
@@ -47,7 +51,7 @@ export function randFlightDetails<Options extends FlightDetailsOptions = never>(
   const factory: () => FlightDetails = () => {
     const airline = options?.airline ?? (randAirline() as Airline);
 
-    const [origin, destination] = randAirport({ length: 2 }) as Airport[];
+    const [origin, destination] = randAirport({ length: 2 });
 
     return {
       passenger: randFullName(),

--- a/packages/falso/src/lib/flight-number.ts
+++ b/packages/falso/src/lib/flight-number.ts
@@ -7,30 +7,27 @@ export type Airline =
   | 'British Airways'
   | 'Iberia'
   | 'EasyJet'
-  | 'Jet2';
+  | 'Jet2'
+  | 'Emirates'
+  | 'American Airlines'
+  | 'JetBlue'
+  | 'Air Europa'
+  | 'Delta Air Lines'
+  | 'United Airlines'
+  | 'Thai Airways'
+  | 'Qatar Airways'
+  | 'Virgin Atlantic';
 
 export interface FlightNumberOptions extends FakeOptions {
   airline?: Airline;
 }
 
-function generateRyanAir(): string {
-  return `FR${getRandomInRange({ min: 1_000, max: 9_999 })}`;
-}
-
-function generateBritishAirways(): string {
-  return `BA${getRandomInRange({ min: 100, max: 999 })}`;
-}
-
-function generateIberia(): string {
-  return `IB${getRandomInRange({ min: 1_000, max: 9_999 })}`;
-}
-
-function generateJet2(): string {
-  return `LS${getRandomInRange({ min: 1_000, max: 9_999 })}`;
-}
-
-function generateEasyJet(): string {
-  return `EZY${getRandomInRange({ min: 100, max: 999 })}`;
+function generateStandardFlightNumber(
+  prefix: string,
+  suffixMin: number,
+  suffixMax: number
+): string {
+  return `${prefix}${getRandomInRange({ min: suffixMin, max: suffixMax })}`;
 }
 
 /**
@@ -54,20 +51,38 @@ function generateEasyJet(): string {
 export function randFlightNumber<Options extends FlightNumberOptions = never>(
   options?: Options
 ) {
-  const airline = options?.airline ?? rand(airlines.data);
+  const airline = options?.airline ?? (rand(airlines.data) as Airline);
 
-  const factory = () => {
+  const factory: () => string = () => {
     switch (airline) {
       case 'RyanAir':
-        return generateRyanAir();
+        return generateStandardFlightNumber('FR', 1_000, 9_999);
       case 'British Airways':
-        return generateBritishAirways();
+        return generateStandardFlightNumber('BA', 100, 999);
       case 'Iberia':
-        return generateIberia();
+        return generateStandardFlightNumber('IB', 1_000, 9_999);
       case 'Jet2':
-        return generateJet2();
+        return generateStandardFlightNumber('LS', 1_000, 9_999);
       case 'EasyJet':
-        return generateEasyJet();
+        return generateStandardFlightNumber('EZY', 100, 999);
+      case 'Emirates':
+        return generateStandardFlightNumber('EK', 10, 99);
+      case 'American Airlines':
+        return generateStandardFlightNumber('AA', 1_000, 9_999);
+      case 'JetBlue':
+        return generateStandardFlightNumber('B', 100, 999);
+      case 'Air Europa':
+        return generateStandardFlightNumber('UX', 1_000, 9_999);
+      case 'Delta Air Lines':
+        return generateStandardFlightNumber('DL', 1_000, 9_999);
+      case 'United Airlines':
+        return generateStandardFlightNumber('UA', 1_000, 9_999);
+      case 'Virgin Atlantic':
+        return generateStandardFlightNumber('VS', 1_000, 9_999);
+      case 'Thai Airways':
+        return generateStandardFlightNumber('TG', 1_000, 9_999);
+      case 'Qatar Airways':
+        return generateStandardFlightNumber('QR', 1_000, 9_999);
       default:
         return getRandomInRange({ min: 10_000, max: 99_999 }).toString();
     }

--- a/packages/falso/src/lib/text-range.ts
+++ b/packages/falso/src/lib/text-range.ts
@@ -22,7 +22,7 @@ export interface TextRangeOptions extends FakeOptions {
  */
 export function randTextRange<Options extends TextRangeOptions = never>(
   options: Options
-): string | string[] {
+) {
   const min = options.min;
   const max = options.max;
 

--- a/packages/falso/src/tests/flight-number.spec.ts
+++ b/packages/falso/src/tests/flight-number.spec.ts
@@ -1,6 +1,7 @@
 import { Airline, randFlightNumber } from '../lib/flight-number';
 import { getRandomInRange } from '../lib/core/core';
 import { seed } from '../lib/random';
+import * as randFunctions from '../lib/rand';
 
 describe('flightNumber', () => {
   describe('RyanAir is passed', () => {
@@ -27,7 +28,6 @@ describe('flightNumber', () => {
     it('should return flight number in correct format', () => {
       const result = randFlightNumber({ airline });
 
-      // TODO: RS - Look into char length
       expect(result).toMatch(/^BA[0-9][0-9][0-9]$/);
     });
   });
@@ -74,18 +74,146 @@ describe('flightNumber', () => {
     });
   });
 
+  describe('Emirates is passed', () => {
+    let airline: Airline;
+
+    beforeEach(() => {
+      airline = 'Emirates';
+    });
+
+    it('should return flight number in correct format', () => {
+      const result = randFlightNumber({ airline });
+
+      expect(result).toMatch(/^EK[1-9][0-9]$/);
+    });
+  });
+
+  describe('American Airlines is passed', () => {
+    let airline: Airline;
+
+    beforeEach(() => {
+      airline = 'American Airlines';
+    });
+
+    it('should return flight number in correct format', () => {
+      const result = randFlightNumber({ airline });
+
+      expect(result).toMatch(/^AA[1-9][0-9][0-9][0-9]$/);
+    });
+  });
+
+  describe('JetBlue is passed', () => {
+    let airline: Airline;
+
+    beforeEach(() => {
+      airline = 'JetBlue';
+    });
+
+    it('should return flight number in correct format', () => {
+      const result = randFlightNumber({ airline });
+
+      expect(result).toMatch(/^B[1-9][0-9][0-9]$/);
+    });
+  });
+
+  describe('Air Europa is passed', () => {
+    let airline: Airline;
+
+    beforeEach(() => {
+      airline = 'Air Europa';
+    });
+
+    it('should return flight number in correct format', () => {
+      const result = randFlightNumber({ airline });
+
+      expect(result).toMatch(/^UX[1-9][0-9][0-9][0-9]$/);
+    });
+  });
+
+  describe('Delta Air Lines is passed', () => {
+    let airline: Airline;
+
+    beforeEach(() => {
+      airline = 'Delta Air Lines';
+    });
+
+    it('should return flight number in correct format', () => {
+      const result = randFlightNumber({ airline });
+
+      expect(result).toMatch(/^DL[1-9][0-9][0-9][0-9]$/);
+    });
+  });
+
+  describe('United Airlines is passed', () => {
+    let airline: Airline;
+
+    beforeEach(() => {
+      airline = 'United Airlines';
+    });
+
+    it('should return flight number in correct format', () => {
+      const result = randFlightNumber({ airline });
+
+      expect(result).toMatch(/^UA[1-9][0-9][0-9][0-9]$/);
+    });
+  });
+
+  describe('Virgin Atlantic is passed', () => {
+    let airline: Airline;
+
+    beforeEach(() => {
+      airline = 'Virgin Atlantic';
+    });
+
+    it('should return flight number in correct format', () => {
+      const result = randFlightNumber({ airline });
+
+      expect(result).toMatch(/^VS[1-9][0-9][0-9][0-9]$/);
+    });
+  });
+
+  describe('Thai Airways is passed', () => {
+    let airline: Airline;
+
+    beforeEach(() => {
+      airline = 'Thai Airways';
+    });
+
+    it('should return flight number in correct format', () => {
+      const result = randFlightNumber({ airline });
+
+      expect(result).toMatch(/^TG[1-9][0-9][0-9][0-9]$/);
+    });
+  });
+
+  describe('Qatar Airways is passed', () => {
+    let airline: Airline;
+
+    beforeEach(() => {
+      airline = 'Qatar Airways';
+    });
+
+    it('should return flight number in correct format', () => {
+      const result = randFlightNumber({ airline });
+
+      expect(result).toMatch(/^QR[1-9][0-9][0-9][0-9]$/);
+    });
+  });
+
   describe('airline is not passed', () => {
-    it("should choose an airline at random and return it's flight number format", () => {
+    let randSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      randSpy = jest.spyOn(randFunctions, 'rand');
+    });
+
+    it('should use airline returned from rand to generate flight number', () => {
+      const airline = 'Iberia';
+      randSpy.mockReturnValue(airline);
+
       const result = randFlightNumber();
 
-      expect(
-        result.match(/LS[0-9][0-9][0-9][0-9]$/) ||
-          result.match(/^EZY[0-9][0-9][0-9]$/) ||
-          result.match(/^IB[0-9][0-9][0-9][0-9]$/) ||
-          result.match(/^BA[0-9][0-9][0-9]$/) ||
-          result.match(/^FR[0-9][0-9][0-9][0-9]$/) ||
-          result.match(/^[1-9][0-9][0-9][0-9][0-9]$/)
-      ).toBeTruthy();
+      expect(result).toMatch(/^IB[0-9][0-9][0-9][0-9]$/);
     });
   });
 

--- a/packages/falso/src/tests/flight-number.spec.ts
+++ b/packages/falso/src/tests/flight-number.spec.ts
@@ -4,6 +4,10 @@ import { seed } from '../lib/random';
 import * as randFunctions from '../lib/rand';
 
 describe('flightNumber', () => {
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
   describe('RyanAir is passed', () => {
     let airline: Airline;
 
@@ -205,6 +209,10 @@ describe('flightNumber', () => {
 
     beforeEach(() => {
       randSpy = jest.spyOn(randFunctions, 'rand');
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
     });
 
     it('should use airline returned from rand to generate flight number', () => {


### PR DESCRIPTION
- Refactor multiple flight number generators into 1 more generic one and add more airlines to switch statement
-Remove return types from Falso functions as they were stopping the typing from automatically working without casting. Add missing documentation




## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
