### PR TITLE
feat: 🔥 Allow users to access falso on doc site console

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -12,6 +12,9 @@ module.exports = {
     favicon: 'img/favicon.ico',
     organizationName: 'ngneat',
     projectName: 'falso',
+    clientModules: [
+        require.resolve('./src/consolePlayground/index.js'),
+    ],
     themeConfig: {
         colorMode: {
             respectPrefersColorScheme: true,

--- a/docs/src/consolePlayground/index.js
+++ b/docs/src/consolePlayground/index.js
@@ -1,0 +1,10 @@
+import * as falso from '../theme/ReactLiveScope/falso.min';
+
+window.onload = function () {
+	const titleStyles = 'color:#8a76d9; font-size: 22px; font-weight:bold;';
+	const copyStyles = 'color:white; font-size: 14px';
+	const exampleStyles = 'color:#8a76d9; font-size: 14px;';
+	console.log('%cFalso\n\n' + '%cYou can use _ to access Falso functions here in the console. \n\n%c' + 'For example: _.randFullName()', titleStyles, copyStyles, exampleStyles)
+
+	window._ = falso;
+};


### PR DESCRIPTION
Add falso.min to window._ so users can try it out from the docs site


https://user-images.githubusercontent.com/7142779/159265162-01a8e5a9-af9b-4692-9aba-ddd92211a21e.mp4



✅ Closes: #225

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
