### PR TITLE
feat: add precision to randNumber

### DIFF
--- a/packages/falso/src/lib/float.ts
+++ b/packages/falso/src/lib/float.ts
@@ -20,10 +20,22 @@ export interface RandomFloatOptions extends RandomInRangeOptions, FakeOptions {}
  *
  * randFloat({ length: 10 })
  *
+ * @example
+ *
+ * randFloat({ min: 10, max: 20, fraction: 1 }) // 12.5
+ *
+ * @example
+ *
+ * randFloat({ min: 10, max: 20, fraction: 2 }) // 12.52
  */
 export function randFloat<Options extends RandomFloatOptions = never>(
   options?: Options
 ) {
-  const o = { ...options, fraction: options?.fraction ?? 2 };
+  const o: RandomFloatOptions = {
+    ...options,
+    fraction: options?.fraction ?? 2,
+  };
   return fake(() => getRandomInRange(o), options);
 }
+
+randFloat();

--- a/packages/falso/src/lib/number.ts
+++ b/packages/falso/src/lib/number.ts
@@ -5,9 +5,8 @@ import {
   RandomInRangeOptions,
 } from './core/core';
 
-export interface RandomNumberOptions extends FakeOptions {
-  min?: number;
-  max?: number;
+export interface RandomNumberOptions extends RandomInRangeOptions, FakeOptions {
+  precision?: number;
 }
 
 /**
@@ -27,14 +26,32 @@ export interface RandomNumberOptions extends FakeOptions {
  *
  * randNumber({ min: 10, max: 1000 }) // default is 'min': 0, 'max': 999_999
  *
+ * @example
+ *
+ * randNumber({ min: 1000, max: 100000, precision: 1000 }) // 67000
+ *
+ * @example
+ *
+ * randNumber({ min: 1000, max: 2000, precision: 100 }) // 1200
+ *
+ * @example
+ *
+ * randNumber({ min: 1000, max: 2000, precision: 10 }) // 1250
  */
 export function randNumber<Options extends RandomNumberOptions = never>(
   options?: Options
 ) {
-  const config: RandomInRangeOptions = {
+  const o: RandomNumberOptions = {
     min: options?.min || 0,
     max: options?.max || 999_999,
+    precision: options?.precision,
   };
 
-  return fake(() => getRandomInRange(config), options);
+  return fake(() => {
+    const num = getRandomInRange(o);
+    if (o.precision !== undefined) {
+      return Math.floor(num / o.precision) * o.precision;
+    }
+    return num;
+  }, options);
 }

--- a/packages/falso/src/tests/number.spec.ts
+++ b/packages/falso/src/tests/number.spec.ts
@@ -1,0 +1,17 @@
+import { randNumber } from '../lib/number';
+
+describe('randNumber', () => {
+  it('should return a random number', () => {
+    const [min, max] = [1, 999_999];
+    const num = randNumber({ min, max });
+    expect(typeof num).toBe('number');
+    expect(num).toBeGreaterThanOrEqual(min);
+    expect(num).toBeLessThanOrEqual(max);
+  });
+
+  it('should support precision', () => {
+    const num = randNumber({ min: 1000, max: 2000, precision: 100 });
+    expect(typeof num).toBe('number');
+    expect(String(num)).toMatch(/^\d\d00$/);
+  });
+});

--- a/packages/falso/src/tests/random-float.spec.ts
+++ b/packages/falso/src/tests/random-float.spec.ts
@@ -24,4 +24,10 @@ describe('random-float', () => {
     expect(randFloat({ max })).toBeLessThanOrEqual(max);
     expect(randFloat({ max })).toBeGreaterThanOrEqual(1.0);
   });
+
+  it('should support fraction', () => {
+    const num = randFloat({ min: 100, max: 200, fraction: 2 });
+    expect(typeof num).toBe('number');
+    expect(String(num)).toMatch(/^\d+\.\d\d$/);
+  });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Cannot specify precision of randNumber

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #226 

## What is the new behavior?

to be able to round numbers to closest 10, 100, 1000 you can set the precision of randNumber

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I hope it conforms to all the coding rules.
:)