### PR TITLE
fix: 🐞 Return an empty array when length is 0

### DIFF
--- a/packages/falso/src/lib/core/core.ts
+++ b/packages/falso/src/lib/core/core.ts
@@ -16,7 +16,7 @@ export function fake<T, Options extends FakeOptions>(
 ): Return<T, Options> {
   const dataSource = Array.isArray(data) ? () => randElement(data) : data;
 
-  if (!options?.length) {
+  if (options?.length === undefined) {
     return dataSource(0) as any;
   }
 

--- a/packages/falso/src/tests/rand.spec.ts
+++ b/packages/falso/src/tests/rand.spec.ts
@@ -12,4 +12,9 @@ describe('rand', () => {
 
     expect(result.length).toEqual(3);
   });
+  it('should return an empty array when length is 0', () => {
+    const result = rand(['a', 'b', 'c'], { length: 0 });
+
+    expect(result).toEqual([]);
+  });
 });


### PR DESCRIPTION
The fix ensures when the user provides a length the helper returns
always an array.

BREAKING CHANGE: 🧨 Setting the option length 0 returns now an array

✅ Closes: #253

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: #253 

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

Calling an helper without the option `length` used to produce the same result as calling it with `0`. Now, setting the `length` to `0` returns an array.

## Other information
