### PR TITLE
Fix randGitShortSha and randGitCommitSha

### DIFF
--- a/packages/falso/src/lib/git-commit-sha.ts
+++ b/packages/falso/src/lib/git-commit-sha.ts
@@ -24,7 +24,7 @@ export function randGitCommitSha<Options extends FakeOptions = never>(
     let sha = '';
 
     for (let i = 0; i < commitShaLen; i++) {
-      sha += randAlphaNumeric();
+      sha += randHexaDecimal();
     }
 
     return sha;

--- a/packages/falso/src/lib/git-commit-sha.ts
+++ b/packages/falso/src/lib/git-commit-sha.ts
@@ -1,5 +1,5 @@
 import { fake, FakeOptions } from './core/core';
-import { randAlphaNumeric } from './alpha-numeric';
+import { randHexaDecimal } from './hexa-decimal';
 
 const commitShaLen = 40;
 

--- a/packages/falso/src/lib/git-short-sha.ts
+++ b/packages/falso/src/lib/git-short-sha.ts
@@ -1,5 +1,5 @@
 import { FakeOptions, fake } from './core/core';
-import { randAlphaNumeric } from './alpha-numeric';
+import { randHexaDecimal } from './hexa-decimal';
 
 const commitShortShaLen = 7;
 

--- a/packages/falso/src/lib/git-short-sha.ts
+++ b/packages/falso/src/lib/git-short-sha.ts
@@ -24,7 +24,7 @@ export function randGitShortSha<Options extends FakeOptions = never>(
     let sha = '';
 
     for (let i = 0; i < commitShortShaLen; i++) {
-      sha += randAlphaNumeric();
+      sha += randHexaDecimal();
     }
 
     return sha;


### PR DESCRIPTION
Seen an error in docs, git commit hash contains only hexa-decimals, but in docs it was any alphanumeric value.
Fixed it