### PR TITLE
Fix Probability distribution

### DIFF
--- a/packages/falso/src/lib/hexa-decimal.ts
+++ b/packages/falso/src/lib/hexa-decimal.ts
@@ -1,11 +1,8 @@
 import { fake, FakeOptions } from './core/core';
 import { randBoolean } from './boolean';
 
-const digits = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-const letters = ['A', 'B', 'C', 'D', 'E', 'F'];
-
 function generator() {
-  return '' + (randBoolean() ? fake(digits) : fake(letters));
+  return randNumber({min:0, max:15}).toString(16);
 }
 
 /**

--- a/packages/falso/src/lib/hexa-decimal.ts
+++ b/packages/falso/src/lib/hexa-decimal.ts
@@ -1,5 +1,5 @@
 import { fake, FakeOptions } from './core/core';
-import { randBoolean } from './boolean';
+import { randNumber } from './number';
 
 function generator() {
   return randNumber({min:0, max:15}).toString(16);


### PR DESCRIPTION
Fix Probability distribution to uniform distribution

Previously, the chance of any random letter and any digit was equal, but the chance of a specific number was 1/(2*10) = 5% and the chance of a specific letter was 1/2/16 = 8.(3)%
Now the chance of a specific number and a specific letter are equals.