### PR TITLE
randWord generates no less than 2 characters

### DIFF
--- a/packages/falso/src/lib/word.ts
+++ b/packages/falso/src/lib/word.ts
@@ -31,7 +31,12 @@ export function randWord<Options extends WordOptions = never>(
   options?: Options
 ) {
   const factory = () => {
-    let word = randElement(data);
+    let word = '';
+
+    // make sure the minimal length is 2 as in some occasions it can be just a letter
+    while (word.length < 2){
+      word = randElement(data);
+    }
 
     if (options?.capitalize) {
       word = capitalizeFirstLetter(word);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

It fixes #260.
`randWord `will now always generate no less than 2 letters

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`randWord` can generate just one letter

Issue Number: #260 

## What is the new behavior?

`randWord` will generate more than one letter with a minimum of 2

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
