### PR TITLE
add support for quick falso access in IDE

### DIFF
--- a/packages/falso/src/index.ts
+++ b/packages/falso/src/index.ts
@@ -1,195 +1,587 @@
-export { randAbbreviation } from './lib/abbreviation';
-export { randAccessory } from './lib/accessory';
-export { randAccount } from './lib/account';
-export { randAlpha } from './lib/alpha';
-export { randAlphaNumeric } from './lib/alpha-numeric';
-export { randAmericanFootballTeam } from './lib/american-football-team';
-export { randAmount } from './lib/amount';
-export { randAnimalType } from './lib/animal-type';
-export { randArn } from './lib/arn';
-export { randAvatar } from './lib/avatar';
-export { randAwsRegion } from './lib/aws-region';
-export { randAwsService } from './lib/aws-service';
-export { randAwsRequestId } from './lib/aws-request-id';
-export { randBaseballTeam } from './lib/baseball-team';
-export { randBasketballTeam } from './lib/basketball-team';
-export { randBear } from './lib/bear';
-export { randBetweenDate } from './lib/between-date';
-export { randBic } from './lib/bic';
-export { randBinary } from './lib/binary';
-export { randBird } from './lib/bird';
-export { randBitcoinAddress } from './lib/bitcoin-address';
-export { randBook, Book } from './lib/book';
-export { randBoolean } from './lib/boolean';
-export { randBrand } from './lib/brand';
-export { randBrowser } from './lib/browser';
-export { randCardinalDirection } from './lib/cardinal-direction';
-export { randCat } from './lib/cat';
-export { randCatchPhrase } from './lib/catch-phrase';
-export { randCetacean } from './lib/cetacean';
-export { randCity } from './lib/city';
-export { randClothingSize } from './lib/clothing-size';
-export { randColor } from './lib/color';
-export { randCompanyName } from './lib/company-name';
-export { randCountry } from './lib/country';
-export { randCountryCode } from './lib/country-code';
-export { randCounty } from './lib/county';
-export { randCow } from './lib/cow';
-export { randCreditCardCVV } from './lib/credit-card-cvv';
-export { randCreditCardBrand } from './lib/credit-card-brand';
-export { randCreditCardNumber } from './lib/credit-card-number';
-export { randCrocodilia } from './lib/crocodilia';
-export { randCurrencyCode } from './lib/currency-code';
-export { randCurrencyName } from './lib/currency-name';
-export { randCurrencySymbol } from './lib/currency-symbol';
-export { randDatabaseCollation } from './lib/database-collation';
-export { randDatabaseColumn } from './lib/database-column';
-export { randDatabaseEngine } from './lib/database-engine';
-export { randDatabaseType } from './lib/database-type';
-export { randDepartment } from './lib/department';
-export { randDirection } from './lib/direction';
-export { randDirectoryPath } from './lib/directory-path';
-export { randDog } from './lib/dog';
-export { randDomainName } from './lib/domain-name';
-export { randDomainSuffix } from './lib/domain-suffix';
-export { randDrinks } from './lib/drinks';
-export { randEmail } from './lib/email';
-export { randEmailProvider } from './lib/email-provider';
-export { randEmoji } from './lib/emoji';
-export { randEthereumAddress } from './lib/ethereum-address';
-export { randFileExt } from './lib/file-ext';
-export { randFileName } from './lib/file-name';
-export { randFilePath } from './lib/file-path';
-export { randFileType } from './lib/file-type';
-export { randFirstName } from './lib/first-name';
-export { randFish } from './lib/fish';
-export { randFloat } from './lib/float';
-export { randFontFamily } from './lib/font-family';
-export { randFontSize } from './lib/font-size';
-export { randFood } from './lib/food';
-export { randFootballTeam } from './lib/football-team';
-export { randFrequency } from './lib/frequency';
-export { randFullName } from './lib/full-name';
-export { randFutureDate } from './lib/future-date';
-export { randGender } from './lib/gender';
-export { randGitBranch } from './lib/git-branch';
-export { randGitCommitEntry } from './lib/git-commit-entry';
-export { randGitCommitMessage } from './lib/git-commit-message';
-export { randGitCommitSha } from './lib/git-commit-sha';
-export { randGitShortSha } from './lib/git-short-sha';
-export { randHex } from './lib/hex';
-export { randHexaDecimal } from './lib/hexa-decimal';
-export { randHorse } from './lib/horse';
-export { randHsl } from './lib/hsl';
-export { randHttpMethod } from './lib/http-method';
-export { randIban } from './lib/iban';
-export { randIceHockeyTeam } from './lib/ice-hockey-team';
-export { randImg } from './lib/img';
-export { randIntegration } from './lib/integration';
-export { randIp } from './lib/ip';
-export { randIpv6 } from './lib/ipv6';
-export { randJobArea } from './lib/job-area';
-export { randJobDescriptor } from './lib/job-descriptor';
-export { randJobTitle } from './lib/job-title';
-export { randJobType } from './lib/job-type';
-export { randLanguage } from './lib/language';
-export { randLastName } from './lib/last-name';
-export { randLatitude } from './lib/latitude';
-export { randLine } from './lib/line';
-export { randLines } from './lib/lines';
-export { randLion } from './lib/lion';
-export { randLocale } from './lib/locale';
-export { randLongitude } from './lib/longitude';
-export { randMac } from './lib/mac';
-export { randMask } from './lib/mask';
-export { randMimeType } from './lib/mime-type';
-export { randMonth } from './lib/month';
-export { randMovie } from './lib/movie';
-export { randMovieCharacter } from './lib/movie-character';
-export { randMusicGenre } from './lib/music-genre';
-export { randNearbyGPSCoordinate } from './lib/nearby-gpscoordinate';
-export { randNumber } from './lib/number';
-export { randOAuthProvider } from './lib/oauth-provider';
-export { randOctal } from './lib/octal';
-export { randOrdinalDirection } from './lib/ordinal-direction';
-export { randParagraph } from './lib/paragraph';
-export { randPassword } from './lib/password';
-export { randPastDate } from './lib/past-date';
-export { randPermission } from './lib/permission';
-export { randPersonTitle } from './lib/person-title';
-export { randPhoneNumber } from './lib/phone-number';
-export { randPhrase } from './lib/phrase';
-export { randPort } from './lib/port';
-export { randPost, Post } from './lib/post';
-export { randPriority } from './lib/priority';
-export { randProduct, Product } from './lib/product';
-export { randProductAdjective } from './lib/product-adjective';
-export { randProductCategory } from './lib/product-category';
-export { randProductDescription } from './lib/product-description';
-export { randProductMaterial } from './lib/product-material';
-export { randProductName } from './lib/product-name';
-export { randProgrammingLanguage } from './lib/programming-language';
-export { randPronoun } from './lib/pronoun';
-export { randProtocol } from './lib/protocol';
-export { randQuote } from './lib/quote';
-export { randRabbit } from './lib/rabbit';
-export { rand } from './lib/rand';
-export { random, seed } from './lib/random';
-export { randRecentDate } from './lib/recent-date';
-export { randRgb } from './lib/rgb';
-export { randRole } from './lib/role';
-export { randRoutingNumber } from './lib/routing-number';
-export { randSemver } from './lib/semver';
-export { randSentence } from './lib/sentence';
-export { randSequence } from './lib/sequence';
-export { randShape } from './lib/shape';
-export { randSkill } from './lib/skill';
-export { randSlug } from './lib/slug';
-export { randSnake } from './lib/snake';
-export { randSocial } from './lib/social';
-export { randSoonDate } from './lib/soon-date';
-export { randSports } from './lib/sports';
-export { randSportsTeam } from './lib/sports-team';
-export { randState } from './lib/state';
-export { randStateAbbr } from './lib/state-abbr';
-export { randStatus } from './lib/status';
-export { randStreetAddress } from './lib/street-address';
-export { randStreetName } from './lib/street-name';
-export { randSubscriptionPlan } from './lib/subscription-plan';
-export { randSuperhero, SuperheroEntity } from './lib/superhero';
-export { randSuperheroName } from './lib/superhero-name';
-export { randSvg } from './lib/svg';
-export { randSwift } from './lib/swift';
-export { randText } from './lib/text';
-export { randTimeZone } from './lib/time-zone';
-export { randTodo, Todo } from './lib/todo';
-export { randTransactionType } from './lib/transaction-type';
-export { randUrl } from './lib/url';
-export { randUser, User } from './lib/user';
-export { randUserAgent } from './lib/user-agent';
-export { randUserName } from './lib/user-name';
-export { randUuid } from './lib/uuid';
-export { randVehicle } from './lib/vehicle';
-export { randVehicleFuel } from './lib/vehicle-fuel';
-export { randVehicleManufacturer } from './lib/vehicle-manufacturer';
-export { randVehicleModel } from './lib/vehicle-model';
-export { randVehicleType } from './lib/vehicle-type';
-export { randVerb } from './lib/verb';
-export { randWeekday } from './lib/weekday';
-export { randWord } from './lib/word';
-export { randZipCode } from './lib/zip-code';
-export { randSinger } from './lib/singer';
-export { randSong } from './lib/song';
-export { randAddress, Address } from './lib/address';
-export { randFullAddress } from './lib/full-address';
-export { randJSON } from './lib/json';
-export { randCodeSnippet } from './lib/code-snippet';
-export { randTextRange } from './lib/text-range';
-export { randFlightNumber } from './lib/flight-number';
-export { randAirline } from './lib/airline';
-export { randFlightDetails, FlightDetails } from './lib/flight-details';
-export { randSeatNumber } from './lib/seat-number';
-export { randAirport } from './lib/airport';
-export { randAirportName } from './lib/airport-name';
-export { randAirportCode } from './lib/airport-code';
-export { randCreditCard } from './lib/credit-card';
+import { randAbbreviation } from './lib/abbreviation';
+import { randAccessory } from './lib/accessory';
+import { randAccount } from './lib/account';
+import { randAlpha } from './lib/alpha';
+import { randAlphaNumeric } from './lib/alpha-numeric';
+import { randAmericanFootballTeam } from './lib/american-football-team';
+import { randAmount } from './lib/amount';
+import { randAnimalType } from './lib/animal-type';
+import { randArn } from './lib/arn';
+import { randAvatar } from './lib/avatar';
+import { randAwsRegion } from './lib/aws-region';
+import { randAwsService } from './lib/aws-service';
+import { randAwsRequestId } from './lib/aws-request-id';
+import { randBaseballTeam } from './lib/baseball-team';
+import { randBasketballTeam } from './lib/basketball-team';
+import { randBear } from './lib/bear';
+import { randBetweenDate } from './lib/between-date';
+import { randBic } from './lib/bic';
+import { randBinary } from './lib/binary';
+import { randBird } from './lib/bird';
+import { randBitcoinAddress } from './lib/bitcoin-address';
+import { randBook, Book } from './lib/book';
+import { randBoolean } from './lib/boolean';
+import { randBrand } from './lib/brand';
+import { randBrowser } from './lib/browser';
+import { randCardinalDirection } from './lib/cardinal-direction';
+import { randCat } from './lib/cat';
+import { randCatchPhrase } from './lib/catch-phrase';
+import { randCetacean } from './lib/cetacean';
+import { randCity } from './lib/city';
+import { randClothingSize } from './lib/clothing-size';
+import { randColor } from './lib/color';
+import { randCompanyName } from './lib/company-name';
+import { randCountry } from './lib/country';
+import { randCountryCode } from './lib/country-code';
+import { randCounty } from './lib/county';
+import { randCow } from './lib/cow';
+import { randCreditCardCVV } from './lib/credit-card-cvv';
+import { randCreditCardBrand } from './lib/credit-card-brand';
+import { randCreditCardNumber } from './lib/credit-card-number';
+import { randCrocodilia } from './lib/crocodilia';
+import { randCurrencyCode } from './lib/currency-code';
+import { randCurrencyName } from './lib/currency-name';
+import { randCurrencySymbol } from './lib/currency-symbol';
+import { randDatabaseCollation } from './lib/database-collation';
+import { randDatabaseColumn } from './lib/database-column';
+import { randDatabaseEngine } from './lib/database-engine';
+import { randDatabaseType } from './lib/database-type';
+import { randDepartment } from './lib/department';
+import { randDirection } from './lib/direction';
+import { randDirectoryPath } from './lib/directory-path';
+import { randDog } from './lib/dog';
+import { randDomainName } from './lib/domain-name';
+import { randDomainSuffix } from './lib/domain-suffix';
+import { randDrinks } from './lib/drinks';
+import { randEmail } from './lib/email';
+import { randEmailProvider } from './lib/email-provider';
+import { randEmoji } from './lib/emoji';
+import { randEthereumAddress } from './lib/ethereum-address';
+import { randFileExt } from './lib/file-ext';
+import { randFileName } from './lib/file-name';
+import { randFilePath } from './lib/file-path';
+import { randFileType } from './lib/file-type';
+import { randFirstName } from './lib/first-name';
+import { randFish } from './lib/fish';
+import { randFloat } from './lib/float';
+import { randFontFamily } from './lib/font-family';
+import { randFontSize } from './lib/font-size';
+import { randFood } from './lib/food';
+import { randFootballTeam } from './lib/football-team';
+import { randFrequency } from './lib/frequency';
+import { randFullName } from './lib/full-name';
+import { randFutureDate } from './lib/future-date';
+import { randGender } from './lib/gender';
+import { randGitBranch } from './lib/git-branch';
+import { randGitCommitEntry } from './lib/git-commit-entry';
+import { randGitCommitMessage } from './lib/git-commit-message';
+import { randGitCommitSha } from './lib/git-commit-sha';
+import { randGitShortSha } from './lib/git-short-sha';
+import { randHex } from './lib/hex';
+import { randHexaDecimal } from './lib/hexa-decimal';
+import { randHorse } from './lib/horse';
+import { randHsl } from './lib/hsl';
+import { randHttpMethod } from './lib/http-method';
+import { randIban } from './lib/iban';
+import { randIceHockeyTeam } from './lib/ice-hockey-team';
+import { randImg } from './lib/img';
+import { randIntegration } from './lib/integration';
+import { randIp } from './lib/ip';
+import { randIpv6 } from './lib/ipv6';
+import { randJobArea } from './lib/job-area';
+import { randJobDescriptor } from './lib/job-descriptor';
+import { randJobTitle } from './lib/job-title';
+import { randJobType } from './lib/job-type';
+import { randLanguage } from './lib/language';
+import { randLastName } from './lib/last-name';
+import { randLatitude } from './lib/latitude';
+import { randLine } from './lib/line';
+import { randLines } from './lib/lines';
+import { randLion } from './lib/lion';
+import { randLocale } from './lib/locale';
+import { randLongitude } from './lib/longitude';
+import { randMac } from './lib/mac';
+import { randMask } from './lib/mask';
+import { randMimeType } from './lib/mime-type';
+import { randMonth } from './lib/month';
+import { randMovie } from './lib/movie';
+import { randMovieCharacter } from './lib/movie-character';
+import { randMusicGenre } from './lib/music-genre';
+import { randNearbyGPSCoordinate } from './lib/nearby-gpscoordinate';
+import { randNumber } from './lib/number';
+import { randOAuthProvider } from './lib/oauth-provider';
+import { randOctal } from './lib/octal';
+import { randOrdinalDirection } from './lib/ordinal-direction';
+import { randParagraph } from './lib/paragraph';
+import { randPassword } from './lib/password';
+import { randPastDate } from './lib/past-date';
+import { randPermission } from './lib/permission';
+import { randPersonTitle } from './lib/person-title';
+import { randPhoneNumber } from './lib/phone-number';
+import { randPhrase } from './lib/phrase';
+import { randPort } from './lib/port';
+import { randPost, Post } from './lib/post';
+import { randPriority } from './lib/priority';
+import { randProduct, Product } from './lib/product';
+import { randProductAdjective } from './lib/product-adjective';
+import { randProductCategory } from './lib/product-category';
+import { randProductDescription } from './lib/product-description';
+import { randProductMaterial } from './lib/product-material';
+import { randProductName } from './lib/product-name';
+import { randProgrammingLanguage } from './lib/programming-language';
+import { randPronoun } from './lib/pronoun';
+import { randProtocol } from './lib/protocol';
+import { randQuote } from './lib/quote';
+import { randRabbit } from './lib/rabbit';
+import { rand } from './lib/rand';
+import { random, seed } from './lib/random';
+import { randRecentDate } from './lib/recent-date';
+import { randRgb } from './lib/rgb';
+import { randRole } from './lib/role';
+import { randRoutingNumber } from './lib/routing-number';
+import { randSemver } from './lib/semver';
+import { randSentence } from './lib/sentence';
+import { randSequence } from './lib/sequence';
+import { randShape } from './lib/shape';
+import { randSkill } from './lib/skill';
+import { randSlug } from './lib/slug';
+import { randSnake } from './lib/snake';
+import { randSocial } from './lib/social';
+import { randSoonDate } from './lib/soon-date';
+import { randSports } from './lib/sports';
+import { randSportsTeam } from './lib/sports-team';
+import { randState } from './lib/state';
+import { randStateAbbr } from './lib/state-abbr';
+import { randStatus } from './lib/status';
+import { randStreetAddress } from './lib/street-address';
+import { randStreetName } from './lib/street-name';
+import { randSubscriptionPlan } from './lib/subscription-plan';
+import { randSuperhero, SuperheroEntity } from './lib/superhero';
+import { randSuperheroName } from './lib/superhero-name';
+import { randSvg } from './lib/svg';
+import { randSwift } from './lib/swift';
+import { randText } from './lib/text';
+import { randTimeZone } from './lib/time-zone';
+import { randTodo, Todo } from './lib/todo';
+import { randTransactionType } from './lib/transaction-type';
+import { randUrl } from './lib/url';
+import { randUser, User } from './lib/user';
+import { randUserAgent } from './lib/user-agent';
+import { randUserName } from './lib/user-name';
+import { randUuid } from './lib/uuid';
+import { randVehicle } from './lib/vehicle';
+import { randVehicleFuel } from './lib/vehicle-fuel';
+import { randVehicleManufacturer } from './lib/vehicle-manufacturer';
+import { randVehicleModel } from './lib/vehicle-model';
+import { randVehicleType } from './lib/vehicle-type';
+import { randVerb } from './lib/verb';
+import { randWeekday } from './lib/weekday';
+import { randWord } from './lib/word';
+import { randZipCode } from './lib/zip-code';
+import { randSinger } from './lib/singer';
+import { randSong } from './lib/song';
+import { randAddress, Address } from './lib/address';
+import { randFullAddress } from './lib/full-address';
+import { randJSON } from './lib/json';
+import { randCodeSnippet } from './lib/code-snippet';
+import { randTextRange } from './lib/text-range';
+import { randFlightNumber } from './lib/flight-number';
+import { randAirline } from './lib/airline';
+import { randFlightDetails, FlightDetails } from './lib/flight-details';
+import { randSeatNumber } from './lib/seat-number';
+import { randAirport } from './lib/airport';
+import { randAirportName } from './lib/airport-name';
+import { randAirportCode } from './lib/airport-code';
+import { randCreditCard } from './lib/credit-card';
+export const randAbbreviation = randAbbreviation;
+export const randAccessory = randAccessory;
+export const randAccount = randAccount;
+export const randAlpha = randAlpha;
+export const randAlphaNumeric = randAlphaNumeric;
+export const randAmericanFootballTeam = randAmericanFootballTeam;
+export const randAmount = randAmount;
+export const randAnimalType = randAnimalType;
+export const randArn = randArn;
+export const randAvatar = randAvatar;
+export const randAwsRegion = randAwsRegion;
+export const randAwsService = randAwsService;
+export const randAwsRequestId = randAwsRequestId;
+export const randBaseballTeam = randBaseballTeam;
+export const randBasketballTeam = randBasketballTeam;
+export const randBear = randBear;
+export const randBetweenDate = randBetweenDate;
+export const randBic = randBic;
+export const randBinary = randBinary;
+export const randBird = randBird;
+export const randBitcoinAddress = randBitcoinAddress;
+export const randBook = randBook;
+export const randBoolean = randBoolean;
+export const randBrand = randBrand;
+export const randBrowser = randBrowser;
+export const randCardinalDirection = randCardinalDirection;
+export const randCat = randCat;
+export const randCatchPhrase = randCatchPhrase;
+export const randCetacean = randCetacean;
+export const randCity = randCity;
+export const randClothingSize = randClothingSize;
+export const randColor = randColor;
+export const randCompanyName = randCompanyName;
+export const randCountry = randCountry;
+export const randCountryCode = randCountryCode;
+export const randCounty = randCounty;
+export const randCow = randCow;
+export const randCreditCardCVV = randCreditCardCVV;
+export const randCreditCardBrand = randCreditCardBrand;
+export const randCreditCardNumber = randCreditCardNumber;
+export const randCrocodilia = randCrocodilia;
+export const randCurrencyCode = randCurrencyCode;
+export const randCurrencyName = randCurrencyName;
+export const randCurrencySymbol = randCurrencySymbol;
+export const randDatabaseCollation = randDatabaseCollation;
+export const randDatabaseColumn = randDatabaseColumn;
+export const randDatabaseEngine = randDatabaseEngine;
+export const randDatabaseType = randDatabaseType;
+export const randDepartment = randDepartment;
+export const randDirection = randDirection;
+export const randDirectoryPath = randDirectoryPath;
+export const randDog = randDog;
+export const randDomainName = randDomainName;
+export const randDomainSuffix = randDomainSuffix;
+export const randDrinks = randDrinks;
+export const randEmail = randEmail;
+export const randEmailProvider = randEmailProvider;
+export const randEmoji = randEmoji;
+export const randEthereumAddress = randEthereumAddress;
+export const randFileExt = randFileExt;
+export const randFileName = randFileName;
+export const randFilePath = randFilePath;
+export const randFileType = randFileType;
+export const randFirstName = randFirstName;
+export const randFish = randFish;
+export const randFloat = randFloat;
+export const randFontFamily = randFontFamily;
+export const randFontSize = randFontSize;
+export const randFood = randFood;
+export const randFootballTeam = randFootballTeam;
+export const randFrequency = randFrequency;
+export const randFullName = randFullName;
+export const randFutureDate = randFutureDate;
+export const randGender = randGender;
+export const randGitBranch = randGitBranch;
+export const randGitCommitEntry = randGitCommitEntry;
+export const randGitCommitMessage = randGitCommitMessage;
+export const randGitCommitSha = randGitCommitSha;
+export const randGitShortSha = randGitShortSha;
+export const randHex = randHex;
+export const randHexaDecimal = randHexaDecimal;
+export const randHorse = randHorse;
+export const randHsl = randHsl;
+export const randHttpMethod = randHttpMethod;
+export const randIban = randIban;
+export const randIceHockeyTeam = randIceHockeyTeam;
+export const randImg = randImg;
+export const randIntegration = randIntegration;
+export const randIp = randIp;
+export const randIpv6 = randIpv6;
+export const randJobArea = randJobArea;
+export const randJobDescriptor = randJobDescriptor;
+export const randJobTitle = randJobTitle;
+export const randJobType = randJobType;
+export const randLanguage = randLanguage;
+export const randLastName = randLastName;
+export const randLatitude = randLatitude;
+export const randLine = randLine;
+export const randLines = randLines;
+export const randLion = randLion;
+export const randLocale = randLocale;
+export const randLongitude = randLongitude;
+export const randMac = randMac;
+export const randMask = randMask;
+export const randMimeType = randMimeType;
+export const randMonth = randMonth;
+export const randMovie = randMovie;
+export const randMovieCharacter = randMovieCharacter;
+export const randMusicGenre = randMusicGenre;
+export const randNearbyGPSCoordinate = randNearbyGPSCoordinate;
+export const randNumber = randNumber;
+export const randOAuthProvider = randOAuthProvider;
+export const randOctal = randOctal;
+export const randOrdinalDirection = randOrdinalDirection;
+export const randParagraph = randParagraph;
+export const randPassword = randPassword;
+export const randPastDate = randPastDate;
+export const randPermission = randPermission;
+export const randPersonTitle = randPersonTitle;
+export const randPhoneNumber = randPhoneNumber;
+export const randPhrase = randPhrase;
+export const randPort = randPort;
+export const randPost = randPost;
+export const randPriority = randPriority;
+export const randProduct = randProduct;
+export const randProductAdjective = randProductAdjective;
+export const randProductCategory = randProductCategory;
+export const randProductDescription = randProductDescription;
+export const randProductMaterial = randProductMaterial;
+export const randProductName = randProductName;
+export const randProgrammingLanguage = randProgrammingLanguage;
+export const randPronoun = randPronoun;
+export const randProtocol = randProtocol;
+export const randQuote = randQuote;
+export const randRabbit = randRabbit;
+export const rand = rand;
+export const random = random;
+export const randRecentDate = randRecentDate;
+export const randRgb = randRgb;
+export const randRole = randRole;
+export const randRoutingNumber = randRoutingNumber;
+export const randSemver = randSemver;
+export const randSentence = randSentence;
+export const randSequence = randSequence;
+export const randShape = randShape;
+export const randSkill = randSkill;
+export const randSlug = randSlug;
+export const randSnake = randSnake;
+export const randSocial = randSocial;
+export const randSoonDate = randSoonDate;
+export const randSports = randSports;
+export const randSportsTeam = randSportsTeam;
+export const randState = randState;
+export const randStateAbbr = randStateAbbr;
+export const randStatus = randStatus;
+export const randStreetAddress = randStreetAddress;
+export const randStreetName = randStreetName;
+export const randSubscriptionPlan = randSubscriptionPlan;
+export const randSuperhero = randSuperhero;
+export const randSuperheroName = randSuperheroName;
+export const randSvg = randSvg;
+export const randSwift = randSwift;
+export const randText = randText;
+export const randTimeZone = randTimeZone;
+export const randTodo = randTodo;
+export const randTransactionType = randTransactionType;
+export const randUrl = randUrl;
+export const randUser = randUser;
+export const randUserAgent = randUserAgent;
+export const randUserName = randUserName;
+export const randUuid = randUuid;
+export const randVehicle = randVehicle;
+export const randVehicleFuel = randVehicleFuel;
+export const randVehicleManufacturer = randVehicleManufacturer;
+export const randVehicleModel = randVehicleModel;
+export const randVehicleType = randVehicleType;
+export const randVerb = randVerb;
+export const randWeekday = randWeekday;
+export const randWord = randWord;
+export const randZipCode = randZipCode;
+export const randSinger = randSinger;
+export const randSong = randSong;
+export const randAddress = randAddress;
+export const randFullAddress = randFullAddress;
+export const randJSON = randJSON;
+export const randCodeSnippet = randCodeSnippet;
+export const randTextRange = randTextRange;
+export const randFlightNumber = randFlightNumber;
+export const randAirline = randAirline;
+export const randFlightDetails = randFlightDetails;
+export const randSeatNumber = randSeatNumber;
+export const randAirport = randAirport;
+export const randAirportName = randAirportName;
+export const randAirportCode = randAirportCode;
+export const randCreditCard = randCreditCard;
+export const falso = {
+    randAbbreviation,
+    randAccessory,
+    randAccount,
+    randAlpha,
+    randAlphaNumeric,
+    randAmericanFootballTeam,
+    randAmount,
+    randAnimalType,
+    randArn,
+    randAvatar,
+    randAwsRegion,
+    randAwsService,
+    randAwsRequestId,
+    randBaseballTeam,
+    randBasketballTeam,
+    randBear,
+    randBetweenDate,
+    randBic,
+    randBinary,
+    randBird,
+    randBitcoinAddress,
+    randBook,
+    randBoolean,
+    randBrand,
+    randBrowser,
+    randCardinalDirection,
+    randCat,
+    randCatchPhrase,
+    randCetacean,
+    randCity,
+    randClothingSize,
+    randColor,
+    randCompanyName,
+    randCountry,
+    randCountryCode,
+    randCounty,
+    randCow,
+    randCreditCardCVV,
+    randCreditCardBrand,
+    randCreditCardNumber,
+    randCrocodilia,
+    randCurrencyCode,
+    randCurrencyName,
+    randCurrencySymbol,
+    randDatabaseCollation,
+    randDatabaseColumn,
+    randDatabaseEngine,
+    randDatabaseType,
+    randDepartment,
+    randDirection,
+    randDirectoryPath,
+    randDog,
+    randDomainName,
+    randDomainSuffix,
+    randDrinks,
+    randEmail,
+    randEmailProvider,
+    randEmoji,
+    randEthereumAddress,
+    randFileExt,
+    randFileName,
+    randFilePath,
+    randFileType,
+    randFirstName,
+    randFish,
+    randFloat,
+    randFontFamily,
+    randFontSize,
+    randFood,
+    randFootballTeam,
+    randFrequency,
+    randFullName,
+    randFutureDate,
+    randGender,
+    randGitBranch,
+    randGitCommitEntry,
+    randGitCommitMessage,
+    randGitCommitSha,
+    randGitShortSha,
+    randHex,
+    randHexaDecimal,
+    randHorse,
+    randHsl,
+    randHttpMethod,
+    randIban,
+    randIceHockeyTeam,
+    randImg,
+    randIntegration,
+    randIp,
+    randIpv6,
+    randJobArea,
+    randJobDescriptor,
+    randJobTitle,
+    randJobType,
+    randLanguage,
+    randLastName,
+    randLatitude,
+    randLine,
+    randLines,
+    randLion,
+    randLocale,
+    randLongitude,
+    randMac,
+    randMask,
+    randMimeType,
+    randMonth,
+    randMovie,
+    randMovieCharacter,
+    randMusicGenre,
+    randNearbyGPSCoordinate,
+    randNumber,
+    randOAuthProvider,
+    randOctal,
+    randOrdinalDirection,
+    randParagraph,
+    randPassword,
+    randPastDate,
+    randPermission,
+    randPersonTitle,
+    randPhoneNumber,
+    randPhrase,
+    randPort,
+    randPost,
+    randPriority,
+    randProduct,
+    randProductAdjective,
+    randProductCategory,
+    randProductDescription,
+    randProductMaterial,
+    randProductName,
+    randProgrammingLanguage,
+    randPronoun,
+    randProtocol,
+    randQuote,
+    randRabbit,
+    rand,
+    random,
+    randRecentDate,
+    randRgb,
+    randRole,
+    randRoutingNumber,
+    randSemver,
+    randSentence,
+    randSequence,
+    randShape,
+    randSkill,
+    randSlug,
+    randSnake,
+    randSocial,
+    randSoonDate,
+    randSports,
+    randSportsTeam,
+    randState,
+    randStateAbbr,
+    randStatus,
+    randStreetAddress,
+    randStreetName,
+    randSubscriptionPlan,
+    randSuperhero,
+    randSuperheroName,
+    randSvg,
+    randSwift,
+    randText,
+    randTimeZone,
+    randTodo,
+    randTransactionType,
+    randUrl,
+    randUser,
+    randUserAgent,
+    randUserName,
+    randUuid,
+    randVehicle,
+    randVehicleFuel,
+    randVehicleManufacturer,
+    randVehicleModel,
+    randVehicleType,
+    randVerb,
+    randWeekday,
+    randWord,
+    randZipCode,
+    randSinger,
+    randSong,
+    randAddress,
+    randFullAddress,
+    randJSON,
+    randCodeSnippet,
+    randTextRange,
+    randFlightNumber,
+    randAirline,
+    randFlightDetails,
+    randSeatNumber,
+    randAirport,
+    randAirportName,
+    randAirportCode,
+    randCreditCard,
+}

--- a/packages/falso/src/index.ts
+++ b/packages/falso/src/index.ts
@@ -193,201 +193,212 @@ import { randAirport } from './lib/airport';
 import { randAirportName } from './lib/airport-name';
 import { randAirportCode } from './lib/airport-code';
 import { randCreditCard } from './lib/credit-card';
-export const randAbbreviation = randAbbreviation;
-export const randAccessory = randAccessory;
-export const randAccount = randAccount;
-export const randAlpha = randAlpha;
-export const randAlphaNumeric = randAlphaNumeric;
-export const randAmericanFootballTeam = randAmericanFootballTeam;
-export const randAmount = randAmount;
-export const randAnimalType = randAnimalType;
-export const randArn = randArn;
-export const randAvatar = randAvatar;
-export const randAwsRegion = randAwsRegion;
-export const randAwsService = randAwsService;
-export const randAwsRequestId = randAwsRequestId;
-export const randBaseballTeam = randBaseballTeam;
-export const randBasketballTeam = randBasketballTeam;
-export const randBear = randBear;
-export const randBetweenDate = randBetweenDate;
-export const randBic = randBic;
-export const randBinary = randBinary;
-export const randBird = randBird;
-export const randBitcoinAddress = randBitcoinAddress;
-export const randBook = randBook;
-export const randBoolean = randBoolean;
-export const randBrand = randBrand;
-export const randBrowser = randBrowser;
-export const randCardinalDirection = randCardinalDirection;
-export const randCat = randCat;
-export const randCatchPhrase = randCatchPhrase;
-export const randCetacean = randCetacean;
-export const randCity = randCity;
-export const randClothingSize = randClothingSize;
-export const randColor = randColor;
-export const randCompanyName = randCompanyName;
-export const randCountry = randCountry;
-export const randCountryCode = randCountryCode;
-export const randCounty = randCounty;
-export const randCow = randCow;
-export const randCreditCardCVV = randCreditCardCVV;
-export const randCreditCardBrand = randCreditCardBrand;
-export const randCreditCardNumber = randCreditCardNumber;
-export const randCrocodilia = randCrocodilia;
-export const randCurrencyCode = randCurrencyCode;
-export const randCurrencyName = randCurrencyName;
-export const randCurrencySymbol = randCurrencySymbol;
-export const randDatabaseCollation = randDatabaseCollation;
-export const randDatabaseColumn = randDatabaseColumn;
-export const randDatabaseEngine = randDatabaseEngine;
-export const randDatabaseType = randDatabaseType;
-export const randDepartment = randDepartment;
-export const randDirection = randDirection;
-export const randDirectoryPath = randDirectoryPath;
-export const randDog = randDog;
-export const randDomainName = randDomainName;
-export const randDomainSuffix = randDomainSuffix;
-export const randDrinks = randDrinks;
-export const randEmail = randEmail;
-export const randEmailProvider = randEmailProvider;
-export const randEmoji = randEmoji;
-export const randEthereumAddress = randEthereumAddress;
-export const randFileExt = randFileExt;
-export const randFileName = randFileName;
-export const randFilePath = randFilePath;
-export const randFileType = randFileType;
-export const randFirstName = randFirstName;
-export const randFish = randFish;
-export const randFloat = randFloat;
-export const randFontFamily = randFontFamily;
-export const randFontSize = randFontSize;
-export const randFood = randFood;
-export const randFootballTeam = randFootballTeam;
-export const randFrequency = randFrequency;
-export const randFullName = randFullName;
-export const randFutureDate = randFutureDate;
-export const randGender = randGender;
-export const randGitBranch = randGitBranch;
-export const randGitCommitEntry = randGitCommitEntry;
-export const randGitCommitMessage = randGitCommitMessage;
-export const randGitCommitSha = randGitCommitSha;
-export const randGitShortSha = randGitShortSha;
-export const randHex = randHex;
-export const randHexaDecimal = randHexaDecimal;
-export const randHorse = randHorse;
-export const randHsl = randHsl;
-export const randHttpMethod = randHttpMethod;
-export const randIban = randIban;
-export const randIceHockeyTeam = randIceHockeyTeam;
-export const randImg = randImg;
-export const randIntegration = randIntegration;
-export const randIp = randIp;
-export const randIpv6 = randIpv6;
-export const randJobArea = randJobArea;
-export const randJobDescriptor = randJobDescriptor;
-export const randJobTitle = randJobTitle;
-export const randJobType = randJobType;
-export const randLanguage = randLanguage;
-export const randLastName = randLastName;
-export const randLatitude = randLatitude;
-export const randLine = randLine;
-export const randLines = randLines;
-export const randLion = randLion;
-export const randLocale = randLocale;
-export const randLongitude = randLongitude;
-export const randMac = randMac;
-export const randMask = randMask;
-export const randMimeType = randMimeType;
-export const randMonth = randMonth;
-export const randMovie = randMovie;
-export const randMovieCharacter = randMovieCharacter;
-export const randMusicGenre = randMusicGenre;
-export const randNearbyGPSCoordinate = randNearbyGPSCoordinate;
-export const randNumber = randNumber;
-export const randOAuthProvider = randOAuthProvider;
-export const randOctal = randOctal;
-export const randOrdinalDirection = randOrdinalDirection;
-export const randParagraph = randParagraph;
-export const randPassword = randPassword;
-export const randPastDate = randPastDate;
-export const randPermission = randPermission;
-export const randPersonTitle = randPersonTitle;
-export const randPhoneNumber = randPhoneNumber;
-export const randPhrase = randPhrase;
-export const randPort = randPort;
-export const randPost = randPost;
-export const randPriority = randPriority;
-export const randProduct = randProduct;
-export const randProductAdjective = randProductAdjective;
-export const randProductCategory = randProductCategory;
-export const randProductDescription = randProductDescription;
-export const randProductMaterial = randProductMaterial;
-export const randProductName = randProductName;
-export const randProgrammingLanguage = randProgrammingLanguage;
-export const randPronoun = randPronoun;
-export const randProtocol = randProtocol;
-export const randQuote = randQuote;
-export const randRabbit = randRabbit;
-export const rand = rand;
-export const random = random;
-export const randRecentDate = randRecentDate;
-export const randRgb = randRgb;
-export const randRole = randRole;
-export const randRoutingNumber = randRoutingNumber;
-export const randSemver = randSemver;
-export const randSentence = randSentence;
-export const randSequence = randSequence;
-export const randShape = randShape;
-export const randSkill = randSkill;
-export const randSlug = randSlug;
-export const randSnake = randSnake;
-export const randSocial = randSocial;
-export const randSoonDate = randSoonDate;
-export const randSports = randSports;
-export const randSportsTeam = randSportsTeam;
-export const randState = randState;
-export const randStateAbbr = randStateAbbr;
-export const randStatus = randStatus;
-export const randStreetAddress = randStreetAddress;
-export const randStreetName = randStreetName;
-export const randSubscriptionPlan = randSubscriptionPlan;
-export const randSuperhero = randSuperhero;
-export const randSuperheroName = randSuperheroName;
-export const randSvg = randSvg;
-export const randSwift = randSwift;
-export const randText = randText;
-export const randTimeZone = randTimeZone;
-export const randTodo = randTodo;
-export const randTransactionType = randTransactionType;
-export const randUrl = randUrl;
-export const randUser = randUser;
-export const randUserAgent = randUserAgent;
-export const randUserName = randUserName;
-export const randUuid = randUuid;
-export const randVehicle = randVehicle;
-export const randVehicleFuel = randVehicleFuel;
-export const randVehicleManufacturer = randVehicleManufacturer;
-export const randVehicleModel = randVehicleModel;
-export const randVehicleType = randVehicleType;
-export const randVerb = randVerb;
-export const randWeekday = randWeekday;
-export const randWord = randWord;
-export const randZipCode = randZipCode;
-export const randSinger = randSinger;
-export const randSong = randSong;
-export const randAddress = randAddress;
-export const randFullAddress = randFullAddress;
-export const randJSON = randJSON;
-export const randCodeSnippet = randCodeSnippet;
-export const randTextRange = randTextRange;
-export const randFlightNumber = randFlightNumber;
-export const randAirline = randAirline;
-export const randFlightDetails = randFlightDetails;
-export const randSeatNumber = randSeatNumber;
-export const randAirport = randAirport;
-export const randAirportName = randAirportName;
-export const randAirportCode = randAirportCode;
-export const randCreditCard = randCreditCard;
+export {
+    Book,
+    Post,
+    Product,
+    seed,
+    SuperheroEntity,
+    Todo,
+    User,
+    Address,
+    FlightDetails,
+    randAbbreviation,
+    randAccessory,
+    randAccount,
+    randAlpha,
+    randAlphaNumeric,
+    randAmericanFootballTeam,
+    randAmount,
+    randAnimalType,
+    randArn,
+    randAvatar,
+    randAwsRegion,
+    randAwsService,
+    randAwsRequestId,
+    randBaseballTeam,
+    randBasketballTeam,
+    randBear,
+    randBetweenDate,
+    randBic,
+    randBinary,
+    randBird,
+    randBitcoinAddress,
+    randBook,
+    randBoolean,
+    randBrand,
+    randBrowser,
+    randCardinalDirection,
+    randCat,
+    randCatchPhrase,
+    randCetacean,
+    randCity,
+    randClothingSize,
+    randColor,
+    randCompanyName,
+    randCountry,
+    randCountryCode,
+    randCounty,
+    randCow,
+    randCreditCardCVV,
+    randCreditCardBrand,
+    randCreditCardNumber,
+    randCrocodilia,
+    randCurrencyCode,
+    randCurrencyName,
+    randCurrencySymbol,
+    randDatabaseCollation,
+    randDatabaseColumn,
+    randDatabaseEngine,
+    randDatabaseType,
+    randDepartment,
+    randDirection,
+    randDirectoryPath,
+    randDog,
+    randDomainName,
+    randDomainSuffix,
+    randDrinks,
+    randEmail,
+    randEmailProvider,
+    randEmoji,
+    randEthereumAddress,
+    randFileExt,
+    randFileName,
+    randFilePath,
+    randFileType,
+    randFirstName,
+    randFish,
+    randFloat,
+    randFontFamily,
+    randFontSize,
+    randFood,
+    randFootballTeam,
+    randFrequency,
+    randFullName,
+    randFutureDate,
+    randGender,
+    randGitBranch,
+    randGitCommitEntry,
+    randGitCommitMessage,
+    randGitCommitSha,
+    randGitShortSha,
+    randHex,
+    randHexaDecimal,
+    randHorse,
+    randHsl,
+    randHttpMethod,
+    randIban,
+    randIceHockeyTeam,
+    randImg,
+    randIntegration,
+    randIp,
+    randIpv6,
+    randJobArea,
+    randJobDescriptor,
+    randJobTitle,
+    randJobType,
+    randLanguage,
+    randLastName,
+    randLatitude,
+    randLine,
+    randLines,
+    randLion,
+    randLocale,
+    randLongitude,
+    randMac,
+    randMask,
+    randMimeType,
+    randMonth,
+    randMovie,
+    randMovieCharacter,
+    randMusicGenre,
+    randNearbyGPSCoordinate,
+    randNumber,
+    randOAuthProvider,
+    randOctal,
+    randOrdinalDirection,
+    randParagraph,
+    randPassword,
+    randPastDate,
+    randPermission,
+    randPersonTitle,
+    randPhoneNumber,
+    randPhrase,
+    randPort,
+    randPost,
+    randPriority,
+    randProduct,
+    randProductAdjective,
+    randProductCategory,
+    randProductDescription,
+    randProductMaterial,
+    randProductName,
+    randProgrammingLanguage,
+    randPronoun,
+    randProtocol,
+    randQuote,
+    randRabbit,
+    rand,
+    random,
+    randRecentDate,
+    randRgb,
+    randRole,
+    randRoutingNumber,
+    randSemver,
+    randSentence,
+    randSequence,
+    randShape,
+    randSkill,
+    randSlug,
+    randSnake,
+    randSocial,
+    randSoonDate,
+    randSports,
+    randSportsTeam,
+    randState,
+    randStateAbbr,
+    randStatus,
+    randStreetAddress,
+    randStreetName,
+    randSubscriptionPlan,
+    randSuperhero,
+    randSuperheroName,
+    randSvg,
+    randSwift,
+    randText,
+    randTimeZone,
+    randTodo,
+    randTransactionType,
+    randUrl,
+    randUser,
+    randUserAgent,
+    randUserName,
+    randUuid,
+    randVehicle,
+    randVehicleFuel,
+    randVehicleManufacturer,
+    randVehicleModel,
+    randVehicleType,
+    randVerb,
+    randWeekday,
+    randWord,
+    randZipCode,
+    randSinger,
+    randSong,
+    randAddress,
+    randFullAddress,
+    randJSON,
+    randCodeSnippet,
+    randTextRange,
+    randFlightNumber,
+    randAirline,
+    randFlightDetails,
+    randSeatNumber,
+    randAirport,
+    randAirportName,
+    randAirportCode,
+    randCreditCard,
+}
 export const falso = {
     randAbbreviation,
     randAccessory,


### PR DESCRIPTION
I would like to have quick access to falso functions from any place in my IDE.
When I type `falso` typescript should recognize a variable from falso package and autoimport it.
Since I dont remember what are falso functions I want to have a list of them somewhere visible in my IDE when I am using falso.
With autoimport I would like import a variable which would contain all of falso functions.

This PR introduce changes

If you have installed falso and you type in you IDE `falso`, hint with available variables is shown. If you pick library it will autoimport a library with variable of your choice.
When you have imported `falso` variable you can type `falso.` and list of all available methods will be shown.

It is what I need if I want to migrate from faker without reducing developer expirience.