### PR TITLE
feat: 🔥 allow date strings for betweenDate

### DIFF
--- a/packages/falso/src/lib/between-date.ts
+++ b/packages/falso/src/lib/between-date.ts
@@ -2,8 +2,8 @@ import { fake, FakeOptions } from './core/core';
 import { randNumber } from './number';
 
 interface BetweenOptions extends FakeOptions {
-  from: Date;
-  to: Date;
+  from: Date | string;
+  to: Date | string;
 }
 
 /**
@@ -23,8 +23,8 @@ interface BetweenOptions extends FakeOptions {
 export function randBetweenDate<Options extends BetweenOptions = never>(
   options: Options
 ) {
-  const from = options.from.getTime();
-  const to = options.to.getTime();
+  const from = new Date(options.from).getTime();
+  const to = new Date(options.to).getTime();
 
   if (from >= to) {
     throw new Error('From must be before to');

--- a/packages/falso/src/tests/between-date.spec.ts
+++ b/packages/falso/src/tests/between-date.spec.ts
@@ -11,6 +11,16 @@ describe('randBetweenDate', () => {
     expect(result.getTime()).toBeLessThan(to.getTime());
   });
 
+  it('should use strings for dates', () => {
+    const from = new Date().toISOString();
+    const to = new Date('12/02/2022').toISOString();
+
+    const result = randBetweenDate({ from, to });
+
+    expect(result.getTime()).toBeGreaterThan(new Date(from).getTime());
+    expect(result.getTime()).toBeLessThan(new Date(to).getTime());
+  });
+
   describe('from date is after to date', () => {
     let from: Date;
     let to: Date;

--- a/packages/falso/src/tests/dates.spec.ts
+++ b/packages/falso/src/tests/dates.spec.ts
@@ -11,6 +11,12 @@ describe('between', () => {
     expect(randBetweenDate({ from, to })).toBeInstanceOf(Date);
   });
 
+  it('should use date strings', () => {
+    const from = new Date(2020, 4, 4).toISOString();
+    const to = new Date(2020, 5, 5).toISOString();
+    expect(randBetweenDate({ from, to })).toBeInstanceOf(Date);
+  });
+
   it('should return a Date between 2020-04-04 and 2020-05-05', () => {
     const from = new Date(2020, 4, 4);
     const to = new Date(2020, 5, 5);


### PR DESCRIPTION
Allow date strings for betweenDate

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`betweenDate` only allows Date objects

Issue Number: N/A

## What is the new behavior?

`betweenDate` now accepts strings as well, which then is converted to Dates automatically

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
