### PR TITLE
fix: Remove unexpected accent from names without accents

### DIFF
--- a/packages/falso/src/lib/last-name.json
+++ b/packages/falso/src/lib/last-name.json
@@ -901,7 +901,7 @@
       "Yu",
       "Yuan",
       "Yusuf",
-      "Zając",
+      "Zajac",
       "Zakharov",
       "Zakharova",
       "Zalewski",

--- a/packages/falso/src/tests/first-name.spec.ts
+++ b/packages/falso/src/tests/first-name.spec.ts
@@ -7,7 +7,7 @@ describe('firstName', () => {
 
   beforeEach(() => {
     specialCharRegex =
-      /[āĀàÀáÁâÂãÃäÄÅåæÆçÇčČćĆðÐēĒèÈéÉêÊĚěëËėĖìÌíÍîÎïÏłŁñÑńŃōŌøØòÒóÓôÔõÕöÖőŐœŒřŘšŠßÞþùÙúÚûÛūŪüÜýÝÿŸžŽżŻ]/;
+      /[āĀàÀáÁâÂãÃäÄÅåæÆąĄçÇčČćĆðÐēĒèÈéÉêÊĚěëËėĖìÌíÍîÎïÏłŁñÑńŃōŌøØòÒóÓôÔõÕöÖőŐœŒřŘšŠßÞþùÙúÚûÛūŪüÜýÝÿŸžŽżŻ]/;
   });
 
   afterAll(() => {
@@ -24,6 +24,16 @@ describe('firstName', () => {
 
         expect(allNames).not.toMatch(specialCharRegex);
       });
+    });
+
+    it('should not contain unexpected special characters', () => {
+      const allNames = [
+        ...data.withoutAccents.male,
+        ...data.withoutAccents.female,
+      ].join('');
+      const notSpecialCharRegex = /[^a-z-]/i;
+
+      expect(allNames).not.toMatch(notSpecialCharRegex);
     });
   });
 

--- a/packages/falso/src/tests/last-name.spec.ts
+++ b/packages/falso/src/tests/last-name.spec.ts
@@ -7,7 +7,7 @@ describe('lastName', () => {
 
   beforeEach(() => {
     specialCharRegex =
-      /[āĀàÀáÁâÂãÃäÄÅåæÆçÇčČćĆðÐēĒèÈéÉêÊĚěëËėĖìÌíÍîÎïÏłŁñÑńŃōŌøØòÒóÓôÔõÕöÖőŐœŒřŘšŠßÞþùÙúÚûÛūŪüÜýÝÿŸžŽżŻ]/;
+      /[āĀàÀáÁâÂãÃäÄÅåæÆąĄçÇčČćĆðÐēĒèÈéÉêÊĚěëËėĖìÌíÍîÎïÏłŁñÑńŃōŌøØòÒóÓôÔõÕöÖőŐœŒřŘšŠßÞþùÙúÚûÛūŪüÜýÝÿŸžŽżŻ]/;
   });
 
   afterAll(() => {
@@ -20,6 +20,13 @@ describe('lastName', () => {
         const allNames = data.withoutAccents.join('');
 
         expect(allNames).not.toMatch(specialCharRegex);
+      });
+
+      it('should not contain unexpected special characters', () => {
+        const allNames = data.withoutAccents.join('');
+        const notSpecialCharRegex = /[^a-z-]/i;
+
+        expect(allNames).not.toMatch(notSpecialCharRegex);
       });
     });
   });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

🐞  There is an unexpected accent that appears in the last names **without** accents.

Issue Number: N/A

## What is the new behavior?

* Remove the unexpected character, `ą`

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

There is a spec that we would have expected to catch this. I've added a new test case to confirm the names without accents do not contain unexpected characters. You may have to update the character group as you add names, such as adding the `'` for `O'Reilly`.

