### PR TITLE
fix: fix max port number

### DIFF
--- a/packages/falso/src/lib/port.ts
+++ b/packages/falso/src/lib/port.ts
@@ -18,5 +18,5 @@ import { randNumber } from './number';
 export function randPort<Options extends FakeOptions = never>(
   options?: Options
 ) {
-  return fake(() => randNumber({ min: 0, max: 65_353 }), options);
+  return fake(() => randNumber({ min: 0, max: 65_535 }), options);
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The current max port number is `65_353`.

## What is the new behavior?

The new max port number is `65_535` ( `= 2^16 - 1`).

See https://stackoverflow.com/questions/113224/what-is-the-largest-tcp-ip-network-port-number-allowable-for-ipv4

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
