### PR TITLE
feat(toCollection): add a new generators to generate collection from …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23461,7 +23461,7 @@
     },
     "packages/falso": {
       "name": "@ngneat/falso",
-      "version": "6.0.3",
+      "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
         "seedrandom": "3.0.5",

--- a/packages/falso/src/index.ts
+++ b/packages/falso/src/index.ts
@@ -202,3 +202,4 @@ export {
   IncrementalDateOptions,
 } from './lib/factories/incremental-date';
 export { randAggregation } from './lib/aggregation';
+export { toCollection } from './lib/collection';

--- a/packages/falso/src/lib/collection.ts
+++ b/packages/falso/src/lib/collection.ts
@@ -18,7 +18,10 @@ import { FakeOptions, fake } from './core/core';
  * }, { length: 10 }) // default is no length.
  *
  */
-export function toCollection<Collection, Options extends FakeOptions = never>(
+export function toCollection<
+  Collection = never,
+  Options extends FakeOptions = never
+>(
   generateCollection: (options?: Options) => Collection,
   options?: Options
 ): Collection | Collection[] {

--- a/packages/falso/src/lib/collection.ts
+++ b/packages/falso/src/lib/collection.ts
@@ -1,0 +1,29 @@
+import { FakeOptions, fake } from './core/core';
+
+/**
+ * Generate a collection from a custom generators functions
+ *
+ * @category util
+ *
+ * @example
+ *
+ * toCollection(() => {
+ *   return { data: randNumber(); }
+ * })
+ *
+ * @example
+ *
+ * toCollection(() => {
+ *   return { data: randNumber(); }
+ * }, { length: 10 }) // default is no length.
+ *
+ */
+export function toCollection<Collection, Options extends FakeOptions = never>(
+  generateCollection: (options?: Options) => Collection,
+  options?: Options
+): Collection | Collection[] {
+  return fake<Collection, Options>(
+    () => generateCollection(options),
+    options
+  ) as Collection | Collection[];
+}

--- a/packages/falso/src/tests/collection.spec.ts
+++ b/packages/falso/src/tests/collection.spec.ts
@@ -1,0 +1,86 @@
+import { toCollection } from '../lib/collection';
+import { randNumber, random, seed } from '@ngneat/falso';
+import * as numberFunctions from '../lib/number';
+import Mock = jest.Mock;
+
+interface fakeData {
+  data: number;
+}
+
+describe('randCollection', () => {
+  it('should create', () => {
+    expect(toCollection).toBeTruthy();
+  });
+
+  it('should return one collection if length is not specified', () => {
+    const expectedData: fakeData = { data: 1 };
+    expect(toCollection<fakeData>(() => expectedData)).toEqual(expectedData);
+  });
+
+  it('should return an array of one collection if length is specified to 1', () => {
+    const expectedData: fakeData = { data: 1 };
+    expect(toCollection<fakeData>(() => expectedData)).toEqual(expectedData);
+    expect(
+      toCollection<fakeData, { length: number }>(() => expectedData, {
+        length: 1,
+      })
+    ).toEqual([expectedData]);
+  });
+
+  it('should return a collection of 2 elements if length=2 specified', () => {
+    const expectedData: fakeData = { data: 1 };
+    expect(
+      toCollection<fakeData, { length: number }>(() => expectedData, {
+        length: 2,
+      })
+    ).toEqual([expectedData, expectedData]);
+  });
+
+  describe('should call generators functions', () => {
+    let generatorFunction: Mock;
+
+    beforeAll(() => {
+      generatorFunction = jest.fn();
+      generatorFunction.mockReturnValue({ data: 1 });
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should return a collection of 2 elements that call another function', () => {
+      const expectedData: fakeData = { data: 1 };
+      expect(
+        toCollection<fakeData, { length: number }>(generatorFunction, {
+          length: 2,
+        })
+      ).toEqual([{ data: 1 }, { data: 1 }]);
+      expect(generatorFunction).toHaveBeenCalledTimes(2);
+      expect(generatorFunction).toHaveBeenCalledWith({ length: 2 });
+    });
+  });
+  describe('with call external random function', () => {
+    let randNumberSpy: jest.SpyInstance;
+
+    beforeAll(() => {
+      randNumberSpy = jest.spyOn(numberFunctions, 'randNumber');
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should return a collection of 2 elements that call another function', () => {
+      const expectedData: fakeData = { data: 1 };
+      randNumberSpy.mockReturnValueOnce(1).mockReturnValueOnce(2);
+      expect(
+        toCollection<fakeData, { length: number }>(
+          () => {
+            return { data: randNumber() };
+          },
+          { length: 2 }
+        )
+      ).toEqual([{ data: 1 }, { data: 2 }]);
+    });
+  });
+});

--- a/packages/falso/src/tests/collection.spec.ts
+++ b/packages/falso/src/tests/collection.spec.ts
@@ -21,7 +21,7 @@ describe('randCollection', () => {
     const expectedData: fakeData = { data: 1 };
     expect(toCollection<fakeData>(() => expectedData)).toEqual(expectedData);
     expect(
-      toCollection<fakeData, { length: number }>(() => expectedData, {
+      toCollection(() => expectedData, {
         length: 1,
       })
     ).toEqual([expectedData]);
@@ -30,7 +30,7 @@ describe('randCollection', () => {
   it('should return a collection of 2 elements if length=2 specified', () => {
     const expectedData: fakeData = { data: 1 };
     expect(
-      toCollection<fakeData, { length: number }>(() => expectedData, {
+      toCollection(() => expectedData, {
         length: 2,
       })
     ).toEqual([expectedData, expectedData]);
@@ -51,7 +51,7 @@ describe('randCollection', () => {
     it('should return a collection of 2 elements that call another function', () => {
       const expectedData: fakeData = { data: 1 };
       expect(
-        toCollection<fakeData, { length: number }>(generatorFunction, {
+        toCollection(generatorFunction, {
           length: 2,
         })
       ).toEqual([{ data: 1 }, { data: 1 }]);
@@ -74,7 +74,7 @@ describe('randCollection', () => {
       const expectedData: fakeData = { data: 1 };
       randNumberSpy.mockReturnValueOnce(1).mockReturnValueOnce(2);
       expect(
-        toCollection<fakeData, { length: number }>(
+        toCollection(
           () => {
             return { data: randNumber() };
           },


### PR DESCRIPTION
…a generator function


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

Generate a collection from a custom generators functions

@category util

@example

toCollection(() => {
  return { data: randNumber(); }
})

@example

toCollection(() => {
  return { data: randNumber(); }
}, { length: 10 }) // default is no length.

It is a wrapper for the internal fake function.




```
[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The fake function is internal and can Not bu used externaly. 

Issue Number: #301 

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x ] No
```

