### PR TITLE
fix: 🐞 randUuid returns the same id multiple times with length parameter

### DIFF
--- a/packages/falso/src/lib/uuid.ts
+++ b/packages/falso/src/lib/uuid.ts
@@ -19,9 +19,11 @@ import { randNumber } from './number';
 export function randUuid<Options extends FakeOptions = never>(
   options?: Options
 ) {
-  const v4options: V4Options = {
-    random: randNumber({ min: 0, max: 255, length: 16 }),
-  };
-
-  return fake(() => uuidv4(v4options), options);
+  return fake(
+    () =>
+      uuidv4({
+        random: randNumber({ min: 0, max: 255, length: 16 }),
+      }),
+    options
+  );
 }

--- a/packages/falso/src/tests/uuid.spec.ts
+++ b/packages/falso/src/tests/uuid.spec.ts
@@ -6,6 +6,11 @@ describe('uuid', () => {
     seed();
   });
 
+  it('should generate different uuids when length option is passed', () => {
+    const arr = randUuid({ length: 2 });
+    expect(arr[0]).not.toEqual(arr[1]);
+  });
+
   it('should generate uuid from seed', () => {
     seed('🙃🔥😊');
     expect(randUuid()).toEqual('02c11a83-1678-4638-9e55-39d543c31599');


### PR DESCRIPTION
randUuid generated a random id and saved it in a constant that was used multiple times

✅ Closes: 313

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
randUuid returns the same id multiple times with the length parameter #313

Issue Number: 313

## What is the new behavior?
randUuid returns different ids with the length parameter

## Does this PR introduce a breaking change?

```
[ ] Yes
[x ] No
```

## Other information
