### PR TITLE
docs: 📘 change elf link to falso link for docusarous

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -48,7 +48,7 @@ module.exports = {
                 className: 'header-icon-link header-sponsor-link',
               },
               {
-                href: 'https://github.com/ngneat/elf/',
+                href: 'https://github.com/ngneat/false/',
                 label: ' ',
                 position: 'right',
                 className: 'header-icon-link header-github-link',
@@ -77,7 +77,7 @@ module.exports = {
                   items: [
                     {
                       label: 'GitHub',
-                      href: 'https://github.com/ngneat/elf',
+                      href: 'https://github.com/ngneat/false',
                     },
                     {
                       label: 'Twitter',

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -34,10 +34,10 @@ function HomepageHeader() {
             style={{ marginLeft: '10px' }}
           >
           <a
-            href="https://github.com/ngneat/elf"
+            href="https://github.com/ngneat/falso"
             rel="noopener"
             target="_blank"
-            aria-label="Star ngneat/elf on GitHub"
+            aria-label="Star ngneat/falso on GitHub"
             style={{
               textDecoration: 'none',
               color: 'inherit',


### PR DESCRIPTION
wrote link is inserted before which indicate elf repository

BREAKING CHANGE: 🧨 no

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

change wrong link in docs

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

docs link indicate falso repository not elf repository


Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
