### PR TITLE
docs: 📘 change wrong path in docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -48,7 +48,7 @@ module.exports = {
                 className: 'header-icon-link header-sponsor-link',
               },
               {
-                href: 'https://github.com/ngneat/false/',
+                href: 'https://github.com/ngneat/falso/',
                 label: ' ',
                 position: 'right',
                 className: 'header-icon-link header-github-link',
@@ -77,7 +77,7 @@ module.exports = {
                   items: [
                     {
                       label: 'GitHub',
-                      href: 'https://github.com/ngneat/false',
+                      href: 'https://github.com/ngneat/falso',
                     },
                     {
                       label: 'Twitter',


### PR DESCRIPTION
change /false => /falso which I made ..
I'm sorry. I'll make sure to check next time!


BREAKING CHANGE: 🧨 no

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

when click github logo in docs people can go this repository

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
