### PR TITLE
refactor: 💡 more type enhancement using built-in keyword

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23832,7 +23832,7 @@
     },
     "packages/falso": {
       "name": "@ngneat/falso",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "license": "MIT",
       "dependencies": {
         "seedrandom": "3.0.5",

--- a/packages/falso/src/lib/food.ts
+++ b/packages/falso/src/lib/food.ts
@@ -1,26 +1,8 @@
 import { fake, FakeOptions, getRandomInRange, randElement } from './core/core';
 import { data } from './food.json';
+import { objectKeys } from './utils/objectKeys';
 
-export type FoodOrigin =
-  | 'china'
-  | 'italy'
-  | 'india'
-  | 'mexico'
-  | 'japan'
-  | 'france'
-  | 'lebanon'
-  | 'thailand'
-  | 'romania'
-  | 'greece'
-  | 'turkey'
-  | 'spain'
-  | 'venezuela'
-  | 'argentina'
-  | 'colombia'
-  | 'chile'
-  | 'peru'
-  | 'el salvador'
-  | 'ecuador';
+export type FoodOrigin = keyof typeof data;
 
 export interface FoodOptions extends FakeOptions {
   origin?: FoodOrigin;
@@ -49,8 +31,8 @@ const totalOrigins = Object.keys(data)?.length;
 export function randFood<Options extends FoodOptions = never>(
   options?: Options
 ) {
-  const foodData: { [origin: string]: string[] } = data;
-  const origin: string | undefined = options?.origin;
+  const foodData: { [key in FoodOrigin]: string[] } = data;
+  const origin: FoodOrigin | undefined = options?.origin;
 
   if (!totalOrigins) {
     throw 'No foods found';
@@ -69,7 +51,7 @@ export function randFood<Options extends FoodOptions = never>(
       min: 0,
       max: totalOrigins - 1,
     });
-    const randomOrigin = Object.keys(foodData)[originIndex];
+    const randomOrigin = objectKeys(foodData)[originIndex];
 
     return randElement(foodData[randomOrigin]);
   };

--- a/packages/falso/src/lib/sports.ts
+++ b/packages/falso/src/lib/sports.ts
@@ -1,9 +1,11 @@
 import { fake, FakeOptions, getRandomInRange, randElement } from './core/core';
 import { data } from './sports.json';
 
+export type Category = keyof typeof data;
+
 export interface SportCategories extends FakeOptions {
   // This categories can be extended in the future
-  category?: 'olympic' | 'outdoor' | 'winterOlympic';
+  category?: Category;
 }
 
 const categoriesCount = Object.keys(data)?.length;

--- a/packages/falso/src/lib/utils/objectKeys.ts
+++ b/packages/falso/src/lib/utils/objectKeys.ts
@@ -1,0 +1,15 @@
+export type ObjectKeys<T extends Record<PropertyKey, unknown>> = Exclude<
+  keyof T,
+  symbol
+>;
+
+/**
+ * A utility function which behaves identical to
+ * [Object.keys()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys).
+ * It preserves type strictly
+ */
+export const objectKeys = <Type extends Record<PropertyKey, unknown>>(
+  obj: Type
+): Array<ObjectKeys<Type>> => {
+  return Object.keys(obj) as Array<ObjectKeys<Type>>;
+};


### PR DESCRIPTION
I made objectKeys which can infer type strictly by behaving identical like Object.keys() function.



## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

In the original code, when data was added in json file, two file had to be modified, but through type inference, even if data is added, only one place(json file) needs to be modified. This increased the ease of maintenance.


Issue Number: N/A
reponed by #324 because of git issue😂

## What is the new behavior?

same as before but increased the ease of maintenance.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
