### PR TITLE
test: 🥳 getRandomInRange can return same value as min value

### DIFF
--- a/packages/falso/src/tests/get-random-in-range.spec.ts
+++ b/packages/falso/src/tests/get-random-in-range.spec.ts
@@ -8,7 +8,7 @@ describe('getRandomInRange', () => {
   });
 
   it('should return number in range', () => {
-    expect(getRandomInRange({ min: 1, max: 10 })).toBeGreaterThan(1);
+    expect(getRandomInRange({ min: 1, max: 10 })).toBeGreaterThanOrEqual(1);
     expect(getRandomInRange({ min: 1, max: 10 })).toBeLessThan(11);
   });
 });


### PR DESCRIPTION
I have verified that the value returned by getRandomInRange may be equal to the min value

![image](https://user-images.githubusercontent.com/69495129/202639094-2bbd64fb-15c7-4135-b0df-7bee849641ae.png)

I tried to modify `getRandomInRange` to return a value greater than the min value always, but I did not modify the function because the developer might think that the return value also contains a min value(can be equal).

Which do you prefer, fixing the test code or modifying the function?



## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?


```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

test code always pass all test

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
