### PR TITLE
fix: change random image service

### DIFF
--- a/packages/falso/src/lib/img.ts
+++ b/packages/falso/src/lib/img.ts
@@ -3,10 +3,8 @@ import { fake, FakeOptions } from './core/core';
 interface ImgOptions extends FakeOptions {
   width?: number;
   height?: number;
-  category?: Category;
+  grayscale?: boolean;
 }
-
-type Category = 'animals' | 'arch' | 'nature' | 'people' | 'tech';
 
 /**
  * Generate a random img.
@@ -21,18 +19,30 @@ type Category = 'animals' | 'arch' | 'nature' | 'people' | 'tech';
  *
  * randImg({ length: 10 })
  *
+ * @example
+ *
+ * randImg({ width: 300 }) // default is "height" or 500 (if not set either)
+ *
+ * @example
+ *
+ * randImg({ height: 200 }) // default is "width" or 500 (if not set either)
+ *
+ * @example
+ *
+ * randImg({ grayscale: true }) // return a grayscale image (default is false)
+ *
  */
 export function randImg<Options extends ImgOptions = never>(options?: Options) {
-  const [width, height, category] = [
-    options?.width ?? 500,
-    options?.height ?? 500,
-    options?.category ?? '',
+  const [width, height, grayscale] = [
+    options?.width ?? options?.height ?? 500,
+    options?.height ?? options?.width ?? 500,
+    options?.grayscale ?? false,
   ];
 
   return fake(
     () =>
-      `https://placeimg.com/${width}/${height}${
-        category ? `/${category}` : category
+      `https://picsum.photos/${width}/${height}${
+        grayscale ? '?grayscale' : ''
       }`,
     options
   );


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->


- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: This PR prevents a future bug (more info below)


## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Issue Number: N/A

The function randImg() returns a URL string using [placeimg.com](https://placeimg.com/), but the service will be shutting down on June 23rd, 2023

## What is the new behavior?

The function randImg() now returns a URL string using [Lorem Picsum](https://picsum.photos/).
This service doesn't support the "category" option, so I removed it.
The service supports other options, I implemented a "grayscale" boolean option.
And last, I changed the default behaviour for "width" and "height" options: now if either of the two options is provided, it return a square image (setting the non-set option equal to the set one).

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Unfortunately the "category" option is not supported by the new service. It will not break anything, but it will not work anymore.

## Other information

I tested this starting from the [6.4.0 tag commit](https://github.com/ngneat/falso/commit/7825746d919119e6fe207ab11c665fcb4c062c0b) and not from `main`, because when I tried the build in my local project it give me this error:
```
yarn run v1.22.19
$ node dist/src/cli/fixtures.js
LOCAL_TEST_PROJECT_PATH/dist/src/cli/fixtures.js:7
const falso_1 = require("@ngneat/falso");
                ^

Error [ERR_REQUIRE_ESM]: require() of ES Module FALSO_DIR_PATH/dist/packages/falso/index.js from LOCAL_TEST_PROJECT_PATH/dist/src/cli/fixtures.js not supported.
Instead change the require of index.js in LOCAL_TEST_PROJECT_PATH/dist/src/cli/fixtures.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (LOCAL_TEST_PROJECT_PATH/dist/src/cli/fixtures.js:7:17) {
  code: 'ERR_REQUIRE_ESM'
}

Node.js v18.14.2
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
Then I rebased onto `main`.