### PR TITLE
fix: 🐞 Fix `randFloat` infinite recursion and logical issue

### DIFF
--- a/packages/falso/src/lib/float.ts
+++ b/packages/falso/src/lib/float.ts
@@ -37,17 +37,7 @@ export function randFloat<Options extends RandomFloatOptions = never>(
   };
 
   function factory(): number {
-    const result = getRandomInRange(o);
-    const stringfiedResult = String(result);
-
-    if (
-      stringfiedResult.includes('.') &&
-      stringfiedResult.split('.')[1].length === o.fraction
-    ) {
-      return result;
-    } else {
-      return factory();
-    }
+    return getRandomInRange(o);
   }
 
   return fake(factory, options);

--- a/packages/falso/src/tests/float.spec.ts
+++ b/packages/falso/src/tests/float.spec.ts
@@ -39,4 +39,8 @@ describe('float', () => {
     expect(typeof num).toBe('number');
     expect(String(num)).toMatch(/^\d+\.\d?\d$/);
   });
+
+  it('should not explode if min and max are equal', () => {
+    expect(randFloat({ min: 1, max: 1 })).toBe(1);
+  });
 });


### PR DESCRIPTION
✅ Closes: #354

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->


- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

`randFloat` produces stack overflow if `min` and `max` are integers and equal:

- Issue Number: #354
- Resolve #354

The underlying issue is that the `randFloat` `factory` refuses to return a number that has fewer than `options.fraction` digits after the decimal point. There is no number between 0 and 0 that has a (required) digit after the decimal place, so the function infinitely recursed.

Moreover, it is very surprising behavior that `randFloat({ min: 0, max: 1, fraction: 2 })` will NEVER return the numbers 0, 0.1, 0.2, ..., 0.9, or 1. If this is expected behavior, it needs to be clearly documented because it likely different from how the user would expect the `randFloat` function to behave.

## What is the new behavior?

- `randFloat({ min: 0, max: 1, fraction: 2 })` can return any number between 0 and 1 that has at most 2 digits after the decimal point. So 0, 0.01, 0.1, and 1 are all possible outputs.
- `randFloat({ min: 0, max: 0 })` returns 0 instead of infinitely recursing.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

