### PR TITLE
add withAccents option to randUserName()

### DIFF
--- a/packages/falso/src/lib/user-name.ts
+++ b/packages/falso/src/lib/user-name.ts
@@ -7,6 +7,7 @@ import { randLastName } from './last-name';
 export interface UserNameOptions extends FakeOptions {
   firstName?: string;
   lastName?: string;
+  withAccents?: boolean;
 }
 
 /**
@@ -30,13 +31,21 @@ export interface UserNameOptions extends FakeOptions {
  *
  * randUserName({ lastName: 'Smee' })
  *
+ * @example
+ *
+ * randUserName({ withAccents: false }) // return username without special symbols like â, î or ô and etc
+ *
  */
 export function randUserName<Options extends UserNameOptions = never>(
   options?: Options
 ) {
+  const nameOptions = {
+    withAccents: options?.withAccents,
+  };
+
   return fake(() => {
-    const firstName = options?.firstName ?? randFirstName();
-    const lastName = options?.lastName ?? randLastName();
+    const firstName = options?.firstName ?? randFirstName(nameOptions);
+    const lastName = options?.lastName ?? randLastName(nameOptions);
     let userName = `${firstName} ${lastName}`.replace(' ', fake(['.', '_']));
 
     if (randBoolean()) {

--- a/packages/falso/src/tests/user-name.spec.ts
+++ b/packages/falso/src/tests/user-name.spec.ts
@@ -30,4 +30,34 @@ describe('username', () => {
       expect(result).toContain(lastName);
     });
   });
+
+  describe('withAccents is passed', () => {
+    let withAccents: boolean;
+    const specialCharRegex =
+      /[āĀàÀáÁâÂãÃäÄÅåæÆçÇčČćĆðÐēĒèÈéÉêÊĚěëËėĖìÌíÍîÎïÏłŁñÑńŃōŌøØòÒóÓôÔõÕöÖőŐœŒřŘšŠßÞþùÙúÚûÛūŪüÜýÝÿŸžŽżŻ]/;
+
+    describe('withAccents is true', () => {
+      beforeEach(() => {
+        withAccents = true;
+      });
+
+      it('should return a string containing accents', () => {
+        const result = randUserName({ withAccents });
+
+        expect(result).toMatch(specialCharRegex);
+      });
+    });
+
+    describe('withAccents is false', () => {
+      beforeEach(() => {
+        withAccents = false;
+      });
+
+      it('should not return a string containing accents', () => {
+        const result = randUserName({ withAccents });
+
+        expect(result).not.toMatch(specialCharRegex);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->


- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`randUserName()` generates random user names including those with accented characters (e.g: `Jiángüo.Karlsdóttir36`)

## What is the new behavior?

with the option: `withAccents: boolean` we can control if the function should generate user names with accents or not
```ts
randUserName({withAccents: false}) // Rattana.Harrison78
randUserName({withAccents: true}) // Dilóp.Háràldsdóttir93
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

