### PR TITLE
feat(img): allow generating random image by default

### DIFF
--- a/packages/falso/src/lib/img.ts
+++ b/packages/falso/src/lib/img.ts
@@ -4,6 +4,7 @@ interface ImgOptions extends FakeOptions {
   width?: number;
   height?: number;
   grayscale?: boolean;
+  random?: boolean;
 }
 
 /**
@@ -30,20 +31,32 @@ interface ImgOptions extends FakeOptions {
  * @example
  *
  * randImg({ grayscale: true }) // return a grayscale image (default is false)
+ * 
+ * @example
+ * 
+ * randImg({ random: true }) // default is true, prevent the image from being cached
  *
  */
 export function randImg<Options extends ImgOptions = never>(options?: Options) {
-  const [width, height, grayscale] = [
+  const [width, height, grayscale, random] = [
     options?.width ?? options?.height ?? 500,
     options?.height ?? options?.width ?? 500,
     options?.grayscale ?? false,
+    options?.random ?? true,
   ];
 
+  const query = new URLSearchParams();
+
+  if (grayscale) {
+    query.append('grayscale', '');
+  }
+
+  if (random) {
+    query.append('random', '1');
+  }
+
   return fake(
-    () =>
-      `https://picsum.photos/${width}/${height}${
-        grayscale ? '?grayscale' : ''
-      }`,
+    () => `https://picsum.photos/${width}/${height}${query.toString()}`,
     options
   );
 }


### PR DESCRIPTION
Previously, the resulting image would be cached by the browser. So, when using `randImg()` on a set of components like React or Solid, the images between components will be the same. I just added the `random` option as described at https://picsum.photos in the Advanced Usage section.

The option `random` should be enabled as it would commonly used in this situation.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/falso/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->


- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
